### PR TITLE
updated setup file to install templates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,9 @@ from setuptools import find_packages, setup
 setup(name='pyntc',
       version='0.0.1',
       packages=find_packages(),
+      package_data={'pyntc': ['templates/*.template']},
       install_requires=['requests>=2.7.0',
                         'jsonschema',
                         'future',
-                       ]
+                        ]
       )


### PR DESCRIPTION
Needed to add a line to install templates (non python files) when using `setup.py install` or pip.