### PR TITLE
Modified setup.py to ensure that it works in 2.65, 2.7.5, & 3.4.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ url = 'https://github.com/networktocode/pyntc'
 download_url = 'https://github.com/networktocode/pyntc/tarball/0.0.5'
 description = 'A multi-vendor library for managing network devices.'
 
-if sys.version_info.major >= 3:
+if sys.version[0] >= 3:
     install_requires.append('textfsm==1.0.1')
     install_requires.append('pyeapi==9.9.9')
     dependency_links.append(

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ url = 'https://github.com/networktocode/pyntc'
 download_url = 'https://github.com/networktocode/pyntc/tarball/0.0.5'
 description = 'A multi-vendor library for managing network devices.'
 
-if sys.version[0] >= 3:
+if int(sys.version[0]) >= 3:
     install_requires.append('textfsm==1.0.1')
     install_requires.append('pyeapi==9.9.9')
     dependency_links.append(


### PR DESCRIPTION
sys.version_info.major is not supported in all versions, but the alternative sys.version[0] appears to function in every version I've been able to test with.