### PR TITLE
Updated dependencies for pyeapi and textfsm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,14 @@ install_requires = [
     'coverage',
     'mock>=1.3',
     'terminal',
-    'textfsm',
 ]
+
+if sys.version_info.major >= 3:
+    install_requires.append('textfsm')
+else:
+    install_requires.append('gtextfsm')
+    install_requires.append('pyeapi')
+    install_requires.append('junos-eznc')
 
 dependency_links = []
 

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,12 @@ install_requires = [
     'future',
     'netmiko',
     'paramiko',
+    'pyeapi',
     'pynxos>=0.0.3',
     'coverage',
     'mock>=1.3',
     'terminal',
+    'textfsm',
 ]
 
 dependency_links = []
@@ -25,20 +27,6 @@ author_email = 'ntc@networktocode.com'
 url = 'https://github.com/networktocode/pyntc'
 download_url = 'https://github.com/networktocode/pyntc/tarball/0.0.5'
 description = 'A multi-vendor library for managing network devices.'
-
-if sys.version_info.major >= 3:
-    install_requires.append('textfsm==1.0.1')
-    install_requires.append('pyeapi==9.9.9')
-    dependency_links.append(
-        'https://github.com/jonathanslenders/textfsm/tarball/master#egg=textfsm-1.0.1'
-    )
-    dependency_links.append(
-        'https://github.com/arista-eosplus/pyeapi/tarball/develop#egg=pyeapi-9.9.9'
-      )
-else:
-    install_requires.append('gtextfsm')
-    install_requires.append('pyeapi')
-    install_requires.append('junos-eznc')
 
 setup(name=name,
       version=version,


### PR DESCRIPTION
The pyeapi and textfsm modules are now natively supported in Python3.  Updated the dependencies to reflect that because the existing dependencies for pyeapi and textfsm listed versions that no longer exist.  The previous textfsm==9.9.9 was renamed to jtextfsm and is now version 0.3.1.  The textfsm module now supports Python3 and is on version 0.3.2.  I didn't specify versions for those modules because there doesn't appear to be a need.  If that is desired, though, the current versions are:  PyEAPI:  0.8.2 and TextFSM: 0.3.2.