### PR TITLE
Global delay factor

### DIFF
--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -36,6 +36,7 @@ class IOSDevice(BaseDevice):
         self.secret = secret
         self.port = int(port)
         self.global_delay_factor = kwargs.get('global_delay_factor', 1)
+        self.delay_factor = kwargs.get('delay_factor', 1)
         self._connected = False
         self.open()
 
@@ -53,6 +54,7 @@ class IOSDevice(BaseDevice):
                                          password=self.password,
                                          port=self.port,
                                          global_delay_factor=self.global_delay_factor,
+                                         delay_factor=self.delay_factor,
                                          secret=self.secret,
                                          verbose=False)
             self._connected = True

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -35,7 +35,7 @@ class IOSDevice(BaseDevice):
         self.password = password
         self.secret = secret
         self.port = int(port)
-        self.global_delay_factor = kwargs.get('global_delay_factor')
+        self.global_delay_factor = kwargs.get('global_delay_factor', 1)
         self._connected = False
         self.open()
 

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -125,7 +125,7 @@ class IOSDevice(BaseDevice):
         command = 'copy running-config %s' % filename
         # Changed to send_command_timing to not require a direct prompt return.
         self.native.send_command_timing(command)
-        # If the user has enabled 'file prompt quiet' which dose not require any confirmation or feedback. This will send return wit        hout requiring an OK.
+        # If the user has enabled 'file prompt quiet' which dose not require any confirmation or feedback. This will send return without requiring an OK.
         # Send a return to pass the [OK]? message - Incease delay_factor for looking for response.
         self.native.send_command_timing('\n',delay_factor=2)
         # Confirm that we have a valid prompt again before returning.

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -54,7 +54,6 @@ class IOSDevice(BaseDevice):
                                          password=self.password,
                                          port=self.port,
                                          global_delay_factor=self.global_delay_factor,
-                                         delay_factor=self.delay_factor,
                                          secret=self.secret,
                                          verbose=False)
             self._connected = True

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -123,10 +123,13 @@ class IOSDevice(BaseDevice):
 
     def save(self, filename='startup-config'):
         command = 'copy running-config %s' % filename
-        expect_string = '\[%s\]' % filename
-        self.show(command, expect=True, expect_string=expect_string)
-        time.sleep(5)
-        self.show('\n')
+        # Changed to send_command_timing to not require a direct prompt return.
+        self.native.send_command_timing(command)
+        # If the user has enabled 'file prompt quiet' which dose not require any confirmation or feedback. This will send return wit        hout requiring an OK.
+        # Send a return to pass the [OK]? message - Incease delay_factor for looking for response.
+        self.native.send_command_timing('\n',delay_factor=2)
+        # Confirm that we have a valid prompt again before returning.
+        self.native.find_prompt()
         return True
 
     def _file_copy_instance(self, src, dest=None, file_system='flash:'):


### PR DESCRIPTION
This is to accompany the following Pull Request on the ntc-ansible (https://github.com/networktocode/ntc-ansible/pull/211)

This adds the global_delay_factor into the ConnectHandler. I did added a default value for this within the module as other ntc_* modules most likely don't support the global_delay_factor and this should prevent errors when running any of those modules.