### PR TITLE
Fix dependency

### DIFF
--- a/pyntc/devices/__init__.py
+++ b/pyntc/devices/__init__.py
@@ -32,7 +32,7 @@ supported_devices = {
     },
     ASA_SSH_DEVICE_TYPE: {
         DEVICE_CLASS_KEY: ASADevice,
-    }
+    },
     F5_API_DEVICE_TYPE: {
         DEVICE_CLASS_KEY: F5Device,
     },

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ install_requires = [
     'terminal',
     'f5-sdk',
     'bigsuds',
+    'pyeapi'
 ]
 
 dependency_links = []
@@ -29,13 +30,7 @@ url = 'https://github.com/networktocode/pyntc'
 download_url = 'https://github.com/networktocode/pyntc/tarball/0.0.6'
 description = 'A multi-vendor library for managing network devices.'
 
-if sys.version_info.major >= 3:
-    install_requires.append('pyeapi==9.9.9')
-    dependency_links.append(
-        'https://github.com/arista-eosplus/pyeapi/tarball/develop#egg=pyeapi-9.9.9'
-      )
-else:
-    install_requires.append('pyeapi')
+if sys.version_info.major < 3:
     install_requires.append('junos-eznc')
 
 setup(name=name,


### PR DESCRIPTION
Trying to address [#14](https://github.com/networktocode/pyntc/issues/14)
Not sure why `pyeapi==9.9.9` was there, since the latest version is actually `0.8.2`