### PR TITLE
IMAGE BOOTED: Move method to an abstract method

### DIFF
--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -55,6 +55,13 @@ class ASADevice(BaseDevice):
         file_system = re.match(r'\s*.*?(\S+:)', raw_data).group(1)
         return file_system
 
+    def _image_booted(self, image_name, **vendor_specifics):
+        version_data = self.show("show version")
+        if re.search(image_name, version_data):
+            return True
+
+        return False
+
     def _interfaces_detailed_list(self):
         ip_int = self.show('show interface')
         ip_int_data = get_structured_data('cisco_asa_show_interface.template',

--- a/pyntc/devices/base_device.py
+++ b/pyntc/devices/base_device.py
@@ -29,6 +29,19 @@ class BaseDevice(object):
         self.vendor = vendor
         self.device_type = device_type
 
+    def _image_booted(self, image_name, **vendor_specifics):
+        """Determines if a particular image is serving as the active OS.
+
+        Args:
+            image_name (str): The image that you would like the device to be using for active OS.
+            vendor_specifics (kwargs):
+                volume: Required by F5Device as F5 boots into a volume.
+
+        Returns:
+            bool: True if image is currently being used by the device, else False.
+        """
+        raise NotImplementedError
+
     ####################
     # ABSTRACT METHODS #
     ####################
@@ -286,22 +299,6 @@ class BaseDevice(object):
     #################################
     # Inherited implemented methods #
     #################################
-    def _image_booted(self, image_name, **vendor_specifics):
-        """Determines if a particular image is serving as the active OS.
-
-        Args:
-            image_name (str): The image that you would like the device to be using for active OS.
-            vendor_specifics (kwargs):
-                volume: Required by F5Device as F5 boots into a volume.
-
-        Returns:
-            bool: True if image is currently being used by the device, else False.
-        """
-        current_image = self.get_boot_options()
-        if current_image["sys"] == image_name:
-            return True
-
-        return False
 
     def feature(self, feature_name):
         """Return a feature class based on the ``feature_name`` for the

--- a/pyntc/devices/eos_device.py
+++ b/pyntc/devices/eos_device.py
@@ -1,6 +1,7 @@
 """Module for using an Arista EOS device over the eAPI.
 """
 
+import re
 import time
 
 from pyntc.errors import CommandError, CommandListError, NTCError
@@ -37,6 +38,13 @@ class EOSDevice(BaseDevice):
         vlan_list = vlans.get_list()
 
         return vlan_list
+
+    def _image_booted(self, image_name, **vendor_specifics):
+        version_data = self.show("show boot", raw_text=True)
+        if re.search(image_name, version_data):
+            return True
+
+        return False
 
     def _interfaces_status_list(self):
         interfaces_list = []

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -56,6 +56,13 @@ class IOSDevice(BaseDevice):
         file_system = re.match(r'\s*.*?(\S+:)', raw_data).group(1)
         return file_system
 
+    def _image_booted(self, image_name, **vendor_specifics):
+        version_data = self.show("show version")
+        if re.search(image_name, version_data):
+            return True
+
+        return False
+
     def _interfaces_detailed_list(self):
         ip_int_br_out = self.show('show ip int br')
         ip_int_br_data = get_structured_data('cisco_ios_show_ip_int_brief.template', ip_int_br_out)

--- a/pyntc/devices/nxos_device.py
+++ b/pyntc/devices/nxos_device.py
@@ -1,6 +1,7 @@
 """Module for using an NXOX device over NX-API.
 """
 import os
+import re
 import time
 
 from pyntc.errors import CommandError, CommandListError
@@ -21,6 +22,13 @@ class NXOSDevice(BaseDevice):
         self.transport = transport
         self.timeout = timeout
         self.native = NXOSNative(host, username, password, transport=transport, timeout=timeout, port=port)
+
+    def _image_booted(self, image_name, **vendor_specifics):
+        version_data = self.show("show version", raw_text=True)
+        if re.search(image_name, version_data):
+            return True
+
+        return False
 
     def _wait_for_device_reboot(self, timeout=3600):
         start = time.time()


### PR DESCRIPTION
  A potential bug was identified where the boot statements could not
match the image booted on the device. Fix is to allow each device to
determine the appropriate way to determine if the image booted is the
image requested.

 * Move inherited method in `base_device` to an abstract method.

 * Create `_image_booted` methods for ASADevice, EOSDevice, IOSDevice,
and NXOSDevice

 * Set EOS and NXOS to use `raw_text` for show version data