### PR TITLE
SET BOOT OPTIONS: Add post-validation to methods

### DIFF
--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -277,6 +277,7 @@ class ASADevice(BaseDevice):
 
     def set_boot_options(self, image_name, **vendor_specifics):
         current_boot = self.show("show running-config | inc ^boot system ")
+        image_location = vendor_specifics.get("image_location", "")
 
         if current_boot:
             current_images = current_boot.splitlines()
@@ -284,10 +285,15 @@ class ASADevice(BaseDevice):
             current_images = []
 
         commands_to_exec = ["no {}".format(image) for image in current_images]
-        commands_to_exec.append("boot system {}{}".format(
-            vendor_specifics.get('image_location', ''), image_name))
+        commands_to_exec.append("boot system {}{}".format(image_location, image_name))
 
         self.config_list(commands_to_exec)
+
+        if self.get_boot_options()["sys"] != image_name:
+            raise CommandError(
+                command="boot system {}{}".format(image_location, image_name),
+                message="Setting boot command did not yield expected results",
+            )
 
     def show(self, command, expect=False, expect_string=''):
         self._enable()

--- a/pyntc/devices/base_device.py
+++ b/pyntc/devices/base_device.py
@@ -256,7 +256,12 @@ class BaseDevice(object):
             The main system image file name.
 
         Keyword Args: many implementors may choose
-            to supply a kickstart parameter to specicify a kickstart image.
+            to supply a kickstart parameter to specify a kickstart image.
+
+        Raises:
+            ValueError: When the boot options returned by the ``get_boot_options``
+                method does not match the ``image_name`` after the config command(s)
+                have been sent to the device.
         """
         raise NotImplementedError
 

--- a/pyntc/devices/eos_device.py
+++ b/pyntc/devices/eos_device.py
@@ -186,6 +186,11 @@ class EOSDevice(BaseDevice):
 
     def set_boot_options(self, image_name, **vendor_specifics):
         self.show('install source %s' % image_name)
+        if self.get_boot_options()["sys"] != image_name:
+            raise CommandError(
+                command="install source {}".format(image_name),
+                message="Setting install source did not yield expected results",
+            )
 
     def show(self, command, raw_text=False):
         try:

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -317,11 +317,18 @@ class IOSDevice(BaseDevice):
 
     def set_boot_options(self, image_name, **vendor_specifics):
         file_system = self._get_file_system()
+
         try:
             self.config_list(['no boot system', 'boot system {0}/{1}'.format(file_system, image_name)])
         except CommandError:
             file_system = file_system.replace(':', '')
             self.config_list(['no boot system', 'boot system {0} {1}'.format(file_system, image_name)])
+
+        if self.get_boot_options()["sys"] != image_name:
+            raise CommandError(
+                command="boot command",
+                message="Setting boot command did not yield expected results",
+            )
 
     def show(self, command, expect=False, expect_string=''):
         self._enable()


### PR DESCRIPTION
 * BaseDevice: Add `Raises` section in docstring for now raising exception for post-validation checks

 * ASADevice: Add validation that boot options were udpate to use `image_name`

 * EOSDevice: Add validation that boot options were udpate to use `image_name`

 * IOSDevice: Add validation that boot options were udpate to use `image_name`