### PR TITLE
SET BOOT OPTIONS: Add support for `file_system`

### DIFF
--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -290,21 +290,18 @@ class ASADevice(BaseDevice):
 
     def set_boot_options(self, image_name, **vendor_specifics):
         current_boot = self.show("show running-config | inc ^boot system ")
-        image_location = vendor_specifics.get("image_location", "")
+        file_system = vendor_specifics.get("file_system")
+        if file_system is None:
+            file_system = self._get_file_system()
 
-        if current_boot:
-            current_images = current_boot.splitlines()
-        else:
-            current_images = []
-
-        commands_to_exec = ["no {}".format(image) for image in current_images]
-        commands_to_exec.append("boot system {}{}".format(image_location, image_name))
-
+        current_images = current_boot.splitlines()
+        commands_to_exec = ["no {0}".format(image) for image in current_images]
+        commands_to_exec.append("boot system {0}/{1}".format(file_system, image_name))
         self.config_list(commands_to_exec)
 
         if self.get_boot_options()["sys"] != image_name:
             raise CommandError(
-                command="boot system {}{}".format(image_location, image_name),
+                command="boot system {0}/{1}".format(file_system, image_name),
                 message="Setting boot command did not yield expected results",
             )
 

--- a/pyntc/devices/base_device.py
+++ b/pyntc/devices/base_device.py
@@ -257,10 +257,14 @@ class BaseDevice(object):
         like system image and kickstart image.
 
         Args:
-            The main system image file name.
+            image_name: The main system image file name.
 
-        Keyword Args: many implementors may choose
-            to supply a kickstart parameter to specify a kickstart image.
+        Keyword Args:
+            kickstart: Option for ``NXOSDevice`` for devices that require a kickstart image.
+            volume: Option for ``F5Device`` to set which volume should have image installed.
+            file_system: Option for ``ASADevice`` and ``IOSDevice`` to set which directory
+                to use when setting the boot path. The default will use the directory returned
+                by the ``_get_file_system()`` method.
 
         Raises:
             ValueError: When the boot options returned by the ``get_boot_options``

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -329,7 +329,9 @@ class IOSDevice(BaseDevice):
         return True
 
     def set_boot_options(self, image_name, **vendor_specifics):
-        file_system = self._get_file_system()
+        file_system = vendor_specifics.get("file_system")
+        if file_system is None:
+            file_system = self._get_file_system()
 
         try:
             self.config_list(['no boot system', 'boot system {0}/{1}'.format(file_system, image_name)])


### PR DESCRIPTION
 * BaseDevice: Update docstring to call out valid keyword arguments and note default `file_system` used by method.

 * IOSDevice: Add check for `file_system` and default to using current `_get_file_system`.

 * ASADevice: Change `image_location` to use `file_sytem` that is used elsewhere.

 * ASADevice: Change default `file_system` to use `_get_file_system` instead of an empty string.

* ASADevice: Simplify `current_images` as using `.splitlines()` works for both conditionals.

 * ASADevice: Add `/` in `boot system {}{}` command to separate file_system` and `image_name` as per device config.