### PR TITLE
SET BOOT OPTIONS: Validate image exists on device before configuring device

### DIFF
--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -294,6 +294,11 @@ class ASADevice(BaseDevice):
         if file_system is None:
             file_system = self._get_file_system()
 
+        file_system_files = self.show("dir {0}".format(file_system))
+        if re.search(image_name, file_system_files) is None:
+            # TODO: Raise proper exception class
+            raise ValueError("Could not find {0} in {1}".format(image_name, file_system))
+
         current_images = current_boot.splitlines()
         commands_to_exec = ["no {0}".format(image) for image in current_images]
         commands_to_exec.append("boot system {0}/{1}".format(file_system, image_name))

--- a/pyntc/devices/eos_device.py
+++ b/pyntc/devices/eos_device.py
@@ -194,6 +194,12 @@ class EOSDevice(BaseDevice):
         return True
 
     def set_boot_options(self, image_name, **vendor_specifics):
+        # TODO: Add support for file_system argument
+        file_system_files = self.show("dir", raw_text=True)
+        if re.search(image_name, file_system_files) is None:
+            # TODO: Raise proper exception class
+            raise ValueError("Could not find {0} in flash:".format(image_name))
+
         self.show('install source %s' % image_name)
         if self.get_boot_options()["sys"] != image_name:
             raise CommandError(

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -333,6 +333,11 @@ class IOSDevice(BaseDevice):
         if file_system is None:
             file_system = self._get_file_system()
 
+        file_system_files = self.show("dir {0}".format(file_system))
+        if re.search(image_name, file_system_files) is None:
+            # TODO: Raise proper exception class
+            raise ValueError("Could not find {0} in {1}".format(image_name, file_system))
+
         try:
             self.config_list(['no boot system', 'boot system {0}/{1}'.format(file_system, image_name)])
         except CommandError:

--- a/pyntc/devices/nxos_device.py
+++ b/pyntc/devices/nxos_device.py
@@ -123,6 +123,16 @@ class NXOSDevice(BaseDevice):
         return self.native.save(filename=filename)
 
     def set_boot_options(self, image_name, kickstart=None, **vendor_specifics):
+        # TODO: Add support for file_system argument
+        file_system_files = self.show("dir", raw_text=True)
+        if re.search(image_name, file_system_files) is None:
+            # TODO: Raise proper exception class
+            raise ValueError("Could not find {0} in bootflash:".format(image_name))
+        if kickstart is not None:
+            if re.search(kickstart, file_system_files) is None:
+                # TODO: Raise proper exception class
+                raise ValueError("Could not find {0} in bootflash:".format(kickstart))
+
         return self.native.set_boot_options(image_name, kickstart=kickstart)
 
     def set_timeout(self, timeout):


### PR DESCRIPTION
 * ASADevice: Add code to look for `image_name` in output of `dir $filesystem`

 * EOSDevice: Add code to look for `image_name` in output of `dir`

 * IOSDevice: Add code to look for `image_name` in output of `dir $filesystem`

 * NXOSDevice: Add code to look for `image_name` in output of `dir`. Add code to look for `kickstart` in output of `dir` when `kickstart` is passed as an argument.