### PR TITLE
EXCEPTIONS: Add FileSystemNotFound

### DIFF
--- a/pyntc/errors.py
+++ b/pyntc/errors.py
@@ -48,3 +48,11 @@ class FeatureNotFoundError(NTCError):
     def __init__(self, feature, device_type):
         message = '%s feature not found for %s device type.' % (feature, device_type)
         super(FeatureNotFoundError, self).__init__(message)
+
+
+class FileSystemNotFoundError(NTCError):
+    def __init__(self, hostname, command):
+        message = 'Unable to parse "{0}" command to identify the default file system on {1}.'.format(
+            command, hostname
+        )
+        super(FileSystemNotFoundError, self).__init__(message)


### PR DESCRIPTION
 * Add Exception class for not being able to parse default file system from device.

 * IOSDevice: Add raising `FileSystemNotFound` exception.

 * ASADevice: Add raising `FileSystemNotFound` exception.

 * BaseDevice: Add doctstring for `_get_file_system` method.

 * F5Device: Add `_get_file_system` method and raise NotImplementedError