### PR TITLE
EXCEPTIONS: Add RebootTimeoutError

### DIFF
--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -9,7 +9,10 @@ import time
 from netmiko import ConnectHandler
 from netmiko import FileTransfer
 
-from pyntc.errors import CommandError, CommandListError, NTCError, FileSystemNotFoundError
+
+from pyntc.errors import (
+    CommandError, CommandListError, NTCError, FileSystemNotFoundError, RebootTimeoutError
+)
 from pyntc.templates import get_structured_data
 from .base_device import BaseDevice, fix_docs
 from .system_features.file_copy.base_file_copy import FileTransferError
@@ -149,11 +152,8 @@ class ASADevice(BaseDevice):
             except:
                 pass
 
-        raise ValueError(
-            "reconnect timeout: could not reconnect {} minutes after device reboot".format(
-                timeout / 60
-            )
-        )
+        # TODO: Get proper hostname parameter
+        raise RebootTimeoutError(hostname=self.host, wait_time=timeout)
 
     def backup_running_config(self, filename):
         with open(filename, 'w') as f:

--- a/pyntc/devices/base_device.py
+++ b/pyntc/devices/base_device.py
@@ -205,6 +205,7 @@ class BaseDevice(object):
             True if system has been installed during function's call, False if OS has not been installed
 
         Raises:
+            RebootTimeoutError: When device is rebooted and is unreachable longer than ``timeout`` period.
             RuntimeError: If there is a problem with OS installation.
         """
         raise NotImplementedError

--- a/pyntc/devices/eos_device.py
+++ b/pyntc/devices/eos_device.py
@@ -4,7 +4,7 @@
 import re
 import time
 
-from pyntc.errors import CommandError, CommandListError, NTCError
+from pyntc.errors import CommandError, CommandListError, NTCError, RebootTimeoutError
 from pyntc.data_model.converters import convert_dict_by_key, \
     convert_list_by_key, strip_unicode
 from pyntc.data_model.key_maps import eos_key_maps
@@ -88,11 +88,7 @@ class EOSDevice(BaseDevice):
             except:
                 pass
 
-        raise ValueError(
-            "reconnect timeout: could not reconnect {} minutes after device reboot".format(
-                timeout / 60
-            )
-        )
+        raise RebootTimeoutError(hostname=self.facts["hostname"], wait_time=timeout)
 
     def backup_running_config(self, filename):
         with open(filename, 'w') as f:

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -6,7 +6,9 @@ import os
 import re
 import time
 
-from pyntc.errors import CommandError, CommandListError, NTCError, FileSystemNotFoundError
+from pyntc.errors import (
+    CommandError, CommandListError, NTCError, FileSystemNotFoundError, RebootTimeoutError
+)
 from pyntc.templates import get_structured_data
 from pyntc.data_model.converters import convert_dict_by_key
 from pyntc.data_model.key_maps import ios_key_maps
@@ -144,11 +146,7 @@ class IOSDevice(BaseDevice):
             except:
                 pass
 
-        raise ValueError(
-            "reconnect timeout: could not reconnect {} minutes after device reboot".format(
-                timeout / 60
-            )
-        )
+        raise RebootTimeoutError(hostname=self.facts["hostname"], wait_time=timeout)
 
     def backup_running_config(self, filename):
         with open(filename, 'w') as f:

--- a/pyntc/devices/jnpr_device.py
+++ b/pyntc/devices/jnpr_device.py
@@ -15,7 +15,7 @@ from jnpr.junos.exception import ConfigLoadError
 from .tables.jnpr.loopback import LoopbackTable
 from .base_device import BaseDevice, fix_docs
 
-from pyntc.errors import CommandError, CommandListError
+from pyntc.errors import CommandError, CommandListError, RebootTimeoutError
 from .system_features.file_copy.base_file_copy import FileTransferError
 
 
@@ -101,11 +101,7 @@ class JunosDevice(BaseDevice):
             except:
                 pass
 
-        raise ValueError(
-            "reconnect timeout: could not reconnect {} minutes after device reboot".format(
-                timeout / 60
-            )
-        )
+        raise RebootTimeoutError(hostname=self.facts["hostname"], wait_time=timeout)
 
     def backup_running_config(self, filename):
         with open(filename, 'w') as f:

--- a/pyntc/devices/nxos_device.py
+++ b/pyntc/devices/nxos_device.py
@@ -4,7 +4,7 @@ import os
 import re
 import time
 
-from pyntc.errors import CommandError, CommandListError
+from pyntc.errors import CommandError, CommandListError, RebootTimeoutError
 from pyntc.data_model.converters import strip_unicode
 from .system_features.file_copy.base_file_copy import FileTransferError
 from .base_device import BaseDevice, RollbackError, RebootTimerError, fix_docs
@@ -39,11 +39,7 @@ class NXOSDevice(BaseDevice):
             except:
                 pass
 
-        raise ValueError(
-            "reconnect timeout: could not reconnect {} minutes after device reboot".format(
-                timeout / 60
-            )
-        )
+        raise RebootTimeoutError(hostname=self.facts["hostname"], wait_time=timeout)
 
     def backup_running_config(self, filename):
         self.native.backup_running_config(filename)

--- a/pyntc/errors.py
+++ b/pyntc/errors.py
@@ -56,3 +56,9 @@ class FileSystemNotFoundError(NTCError):
             command, hostname
         )
         super(FileSystemNotFoundError, self).__init__(message)
+
+
+class RebootTimeoutError(NTCError):
+    def __init__(self, hostname, wait_time):
+        message = "Unable to reconnect to {0} after {1} seconds".format(hostname, wait_time)
+        super(RebootTimeoutError, self).__init__(message)


### PR DESCRIPTION
 * BaseDevice: Add `RebootTimeoutError` to exceptions documentation in `install_os` method.

 * ASADevice: Change `_wait_for_device_reboot` to use `RebootTimeoutError` when unable to reconnect to device.

 * EOSDevice: Change `_wait_for_device_reboot` to use `RebootTimeoutError` when unable to reconnect to device.

 * IOSDevice: Change `_wait_for_device_reboot` to use `RebootTimeoutError` when unable to reconnect to device.

 * JunosDevice: `_wait_for_device_reboot` to use `RebootTimeoutError` when unable to reconnect to device.

 * NXOSDevice: `_wait_for_device_reboot` to use `RebootTimeoutError` when unable to reconnect to device.