### PR TITLE
EXCEPTIONS: Add `NotEnoughFreeSpace` exception

### DIFF
--- a/pyntc/errors.py
+++ b/pyntc/errors.py
@@ -62,3 +62,11 @@ class RebootTimeoutError(NTCError):
     def __init__(self, hostname, wait_time):
         message = "Unable to reconnect to {0} after {1} seconds".format(hostname, wait_time)
         super(RebootTimeoutError, self).__init__(message)
+
+
+class NotEnoughFreeSpace(NTCError):
+    def __init__(self, hostname, min_space):
+        message = "{0} does not meet the minimum disk space requirements of {1}".format(
+            hostname, min_space
+        )
+        super(NotEnoughFreeSpace, self).__init__(message)


### PR DESCRIPTION
 * Add exception class to errors file

 * F5Device: Change `_check_free_space` method to raise `NotEnoughFreeSpace` when the device does not meet `min_space` requirements.

 * F5Device: Change methods using to `_check_free_space` to allow exception to be raised in method call.