### PR TITLE
EXCEPTIONS: Add `OSInstallError` exception class

### DIFF
--- a/pyntc/errors.py
+++ b/pyntc/errors.py
@@ -70,3 +70,9 @@ class NotEnoughFreeSpace(NTCError):
             hostname, min_space
         )
         super(NotEnoughFreeSpace, self).__init__(message)
+
+
+class OSInstallError(NTCError):
+    def __init__(self, hostname, desired_boot):
+        message = "{0} was unable to boot into {1}".format(hostname, desired_boot)
+        super(OSInstallError, self).__init__(message)


### PR DESCRIPTION
 * Add exception class to pyntc/errors.py

 * F5Device: Change `_wait_for_image_installed` method to return `None` and raise `OSInstallError` when install does not complete within wait time.

 * F5Device: Change `set_boot_options` to allow install exception happen in `_wait_for_image_installed` method.