### PR TITLE
EXCEPTIONS: Add `NTCFileNotFoundError` exception.

### DIFF
--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -11,7 +11,12 @@ from netmiko import FileTransfer
 
 
 from pyntc.errors import (
-    CommandError, CommandListError, NTCError, FileSystemNotFoundError, RebootTimeoutError
+    CommandError,
+    CommandListError,
+    FileSystemNotFoundError,
+    NTCError,
+    NTCFileNotFoundError,
+    RebootTimeoutError,
 )
 from pyntc.templates import get_structured_data
 from .base_device import BaseDevice, fix_docs
@@ -308,8 +313,9 @@ class ASADevice(BaseDevice):
 
         file_system_files = self.show("dir {0}".format(file_system))
         if re.search(image_name, file_system_files) is None:
-            # TODO: Raise proper exception class
-            raise ValueError("Could not find {0} in {1}".format(image_name, file_system))
+            raise NTCFileNotFoundError(
+                hostname=self.facts.get("hostname"), file=image_name, dir=file_system
+            )
 
         current_images = current_boot.splitlines()
         commands_to_exec = ["no {0}".format(image) for image in current_images]

--- a/pyntc/devices/eos_device.py
+++ b/pyntc/devices/eos_device.py
@@ -15,6 +15,7 @@ from pyntc.errors import (
     CommandListError,
     FileSystemNotFoundError,
     NTCError,
+    NTCFileNotFoundError,
     RebootTimeoutError,
 )
 
@@ -218,8 +219,9 @@ class EOSDevice(BaseDevice):
 
         file_system_files = self.show("dir {0}".format(file_system), raw_text=True)
         if re.search(image_name, file_system_files) is None:
-            # TODO: Raise proper exception class
-            raise ValueError("Could not find {0} in flash:".format(image_name))
+            raise NTCFileNotFoundError(
+                hostname=self.facts.get("hostname"), file=image_name, dir=file_system
+            )
 
         self.show('install source {0}{1}'.format(file_system, image_name))
         if self.get_boot_options()["sys"] != image_name:

--- a/pyntc/devices/f5_device.py
+++ b/pyntc/devices/f5_device.py
@@ -12,7 +12,7 @@ from f5.bigip import ManagementRoot
 
 from .base_device import BaseDevice
 from .system_features.file_copy.base_file_copy import FileTransferError
-from pyntc.errors import NotEnoughFreeSpace, OSInstallError
+from pyntc.errors import NotEnoughFreeSpaceError, OSInstallError
 
 
 class F5Device(BaseDevice):
@@ -34,7 +34,7 @@ class F5Device(BaseDevice):
             min_space (int): The minimal amount of space required.
 
         Raises:
-            NotEnoughFreeSpace: When the amount of space on the device is less than min_space.
+            NotEnoughFreeSpaceError: When the amount of space on the device is less than min_space.
         """
         free_space = self._get_free_space()
 
@@ -43,7 +43,7 @@ class F5Device(BaseDevice):
         elif free_space >= min_space:
             return
         elif free_space < min_space:
-            raise NotEnoughFreeSpace(hostname=self.facts.get("hostname"), min_space=min_space)
+            raise NotEnoughFreeSpaceError(hostname=self.facts.get("hostname"), min_space=min_space)
 
     def _check_md5sum(self, filename, checksum):
         """Checks if md5sum is correct

--- a/pyntc/devices/nxos_device.py
+++ b/pyntc/devices/nxos_device.py
@@ -4,10 +4,15 @@ import os
 import re
 import time
 
-from pyntc.errors import CommandError, CommandListError, RebootTimeoutError
 from pyntc.data_model.converters import strip_unicode
 from .system_features.file_copy.base_file_copy import FileTransferError
 from .base_device import BaseDevice, RollbackError, RebootTimerError, fix_docs
+from pyntc.errors import (
+    CommandError,
+    CommandListError,
+    NTCFileNotFoundError,
+    RebootTimeoutError,
+)
 
 from pynxos.device import Device as NXOSNative
 from pynxos.features.file_copy import FileTransferError as NXOSFileTransferError
@@ -125,12 +130,14 @@ class NXOSDevice(BaseDevice):
 
         file_system_files = self.show("dir {0}".format(file_system), raw_text=True)
         if re.search(image_name, file_system_files) is None:
-            # TODO: Raise proper exception class
-            raise ValueError("Could not find {0} in {1}".format(image_name, file_system))
+            raise NTCFileNotFoundError(
+                hostname=self.facts.get("hostname"), file=image_name, dir=file_system
+            )
         if kickstart is not None:
             if re.search(kickstart, file_system_files) is None:
-                # TODO: Raise proper exception class
-                raise ValueError("Could not find {0} in {1}".format(kickstart, file_system))
+                raise NTCFileNotFoundError(
+                    hostname=self.facts.get("hostname"), file=image_name, dir=file_system
+                )
 
             kickstart = file_system + kickstart
 

--- a/pyntc/errors.py
+++ b/pyntc/errors.py
@@ -64,7 +64,7 @@ class RebootTimeoutError(NTCError):
         super(RebootTimeoutError, self).__init__(message)
 
 
-class NotEnoughFreeSpace(NTCError):
+class NotEnoughFreeSpaceError(NTCError):
     def __init__(self, hostname, min_space):
         message = "{0} does not meet the minimum disk space requirements of {1}".format(
             hostname, min_space
@@ -76,3 +76,9 @@ class OSInstallError(NTCError):
     def __init__(self, hostname, desired_boot):
         message = "{0} was unable to boot into {1}".format(hostname, desired_boot)
         super(OSInstallError, self).__init__(message)
+
+
+class NTCFileNotFoundError(NTCError):
+    def __init__(self, hostname, file, dir):
+        message = "{0} was not found in {1} on {2}".format(file, dir, hostname)
+        super(NTCFileNotFoundError, self).__init__(message)


### PR DESCRIPTION
 * Add `NTCFileNotFoundError` to pyntc/errors.py.
 * Add "Error" to `NotEnoughFreeSpace` exception to make it `NotEnoughFreeSpaceError`.

 * ASADevice, EOSDevice, IOSDevice, NXOSDevice:
    - Reformat lengthy exception imports
    - Add exception as part of `set_boot_options` method.

 * F5Device:
    - Update import name for `NotEnoughFreeSpace`.
    - Update implementations of `NotEnoughFreeSpace`.