### PR TITLE
INSTALL OS: Add method that performs install of OS

### DIFF
--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -246,7 +246,6 @@ class ASADevice(BaseDevice):
         timeout = vendor_specifics.get("timeout", 3600)
         if not self._image_booted(image_name):
             self.set_boot_options(image_name, **vendor_specifics)
-            self.save()
             self.reboot(confirm=True)
             self._wait_for_device_reboot(timeout=timeout)
             if not self._image_booted(image_name):
@@ -336,6 +335,7 @@ class ASADevice(BaseDevice):
         commands_to_exec.append("boot system {0}/{1}".format(file_system, image_name))
         self.config_list(commands_to_exec)
 
+        self.save()
         if self.get_boot_options()["sys"] != image_name:
             raise CommandError(
                 command="boot system {0}/{1}".format(file_system, image_name),

--- a/pyntc/devices/base_device.py
+++ b/pyntc/devices/base_device.py
@@ -192,6 +192,39 @@ class BaseDevice(object):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def install_os(self, image_name, **vendor_specifics):
+        """Install the OS from specified image_name
+
+        Args:
+            image_name(str): The name of the image on the device to install.
+
+        Keyword Args:
+            kickstart (str): Option for ``NXOSDevice`` for devices that require a kickstart image.
+            volume (str): Option for ``F5Device`` to set the target boot volume.
+            file_system (str): Option for ``ASADevice``, ``EOSDevice``, ``IOSDevice``, and
+                ``NXOSDevice`` to set where the OS files are stored. The default will use
+                the ``_get_file_system`` method.
+            timeout (int): Option for ``IOSDevice`` and ``NXOSDevice`` to set the wait time for
+                device installation to complete.
+
+        Returns:
+            True if system has been installed during function's call, False if OS has not been installed
+
+        Raises:
+            OSInstallError: When device finishes installation process, but the running image
+                does not match ``image_name``.
+            CommandError: When sending a command to the device fails, or when the config status
+                after sending a command does not yield expected results.
+            CommandListError: When sending commands to the device fails.
+            NotEnoughFreeSpaceError: When the device does not have enough free space for install.
+            NTCFileNotFoundError: When the ``image_name`` is not found in the devices ``file_system``.
+            FileSystemNotFoundError: When the ``file_system`` is left to default,
+                and the ``file_system`` cannot be identified.
+            RebootTimeoutError: When device is rebooted and is unreachable longer than ``timeout`` period.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def open(self):
         """Open a connection to the device.
         """

--- a/pyntc/devices/eos_device.py
+++ b/pyntc/devices/eos_device.py
@@ -17,6 +17,7 @@ from pyntc.errors import (
     NTCError,
     NTCFileNotFoundError,
     RebootTimeoutError,
+    OSInstallError,
 )
 
 from pyeapi import connect as eos_connect
@@ -179,6 +180,19 @@ class EOSDevice(BaseDevice):
         image = self.show('show boot-config')['softwareImage']
         image = image.replace('flash:', '')
         return dict(sys=image)
+
+    def install_os(self, image_name, **vendor_specifics):
+        timeout = vendor_specifics.get("timeout", 3600)
+        if not self._image_booted(image_name):
+            self.set_boot_options(image_name, **vendor_specifics)
+            self.reboot(confirm=True)
+            self._wait_for_device_reboot(timeout=timeout)
+            if not self._image_booted(image_name):
+                raise OSInstallError(hostname=self.facts.get("hostname"), desired_boot=image_name)
+
+            return True
+
+        return False
 
     def open(self):
         pass

--- a/pyntc/devices/f5_device.py
+++ b/pyntc/devices/f5_device.py
@@ -354,8 +354,13 @@ class F5Device(BaseDevice):
 
         while time.time() < end_time:
             time.sleep(20)
-            if self.image_installed(image_name=image_name, volume=volume):
-                return
+            # Avoid race-conditions issues. Newly created volumes _might_ lack
+            # of .version attribute in first seconds of their live.
+            try:
+                if self.image_installed(image_name=image_name, volume=volume):
+                    return
+            except:
+                pass
 
         raise OSInstallError(hostname=self.facts.get("hostname"), desired_boot=volume)
 

--- a/pyntc/devices/f5_device.py
+++ b/pyntc/devices/f5_device.py
@@ -10,9 +10,10 @@ import bigsuds
 import requests
 from f5.bigip import ManagementRoot
 
+from pyntc.errors import NotEnoughFreeSpaceError, OSInstallError, \
+    NTCFileNotFoundError
 from .base_device import BaseDevice
 from .system_features.file_copy.base_file_copy import FileTransferError
-from pyntc.errors import NotEnoughFreeSpaceError, OSInstallError
 
 
 class F5Device(BaseDevice):
@@ -449,6 +450,11 @@ class F5Device(BaseDevice):
         volume = vendor_specifics.get('volume')
         if not self.image_installed(image_name, volume):
             self._check_free_space(min_space=6)
+            if not self._image_exists(image_name):
+                raise NTCFileNotFoundError(
+                    hostname=self._get_hostname(), file=image_name,
+                    dir='/shared/images'
+                )
             self._image_install(image_name=image_name, volume=volume)
             self._wait_for_image_installed(image_name=image_name, volume=volume)
 
@@ -485,6 +491,11 @@ class F5Device(BaseDevice):
     def set_boot_options(self, image_name, **vendor_specifics):
         volume = vendor_specifics.get('volume')
         self._check_free_space(min_space=6)
+        if not self._image_exists(image_name):
+            raise NTCFileNotFoundError(
+                hostname=self._get_hostname(), file=image_name,
+                dir='/shared/images'
+            )
         self._image_install(image_name=image_name, volume=volume)
         self._wait_for_image_installed(image_name=image_name, volume=volume)
 

--- a/pyntc/devices/f5_device.py
+++ b/pyntc/devices/f5_device.py
@@ -338,7 +338,7 @@ class F5Device(BaseDevice):
                 pass
         return False
 
-    def _wait_for_image_installed(self, image_name, volume, timeout=900):
+    def _wait_for_image_installed(self, image_name, volume, timeout=1800):
         """Waits for the device to install image on a volume
 
         Args:
@@ -395,7 +395,6 @@ class F5Device(BaseDevice):
         if not self.file_copy_remote_exists(src, dest, **kwargs):
             self._check_free_space(min_space=6)
             self._upload_image(image_filepath=src)
-
             if not self.file_copy_remote_exists(src, dest, **kwargs):
                 raise FileTransferError(
                     message="Attempted file copy, "
@@ -443,6 +442,17 @@ class F5Device(BaseDevice):
             for _volume in volumes:
                 if _volume.name == volume and _volume.version == image.version and _volume.basebuild == image.build and _volume.status == 'complete':
                     return True
+
+        return False
+
+    def install_os(self, image_name, **vendor_specifics):
+        volume = vendor_specifics.get('volume')
+        if not self.image_installed(image_name, volume):
+            self._check_free_space(min_space=6)
+            self._image_install(image_name=image_name, volume=volume)
+            self._wait_for_image_installed(image_name=image_name, volume=volume)
+
+            return True
 
         return False
 

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -17,6 +17,7 @@ from pyntc.errors import (
     FileSystemNotFoundError,
     NTCError,
     NTCFileNotFoundError,
+    OSInstallError,
     RebootTimeoutError,
 )
 
@@ -270,6 +271,20 @@ class IOSDevice(BaseDevice):
             boot_image = None
 
         return {'sys': boot_image}
+
+    def install_os(self, image_name, **vendor_specifics):
+        timeout = vendor_specifics.get("timeout", 3600)
+        if not self._image_booted(image_name):
+            self.set_boot_options(image_name, **vendor_specifics)
+            self.save()
+            self.reboot(confirm=True)
+            self._wait_for_device_reboot(timeout=timeout)
+            if not self._image_booted(image_name):
+                raise OSInstallError(hostname=self.facts.get("hostname"), desired_boot=image_name)
+
+            return True
+
+        return False
 
     def open(self):
         if self._connected:

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -276,7 +276,6 @@ class IOSDevice(BaseDevice):
         timeout = vendor_specifics.get("timeout", 3600)
         if not self._image_booted(image_name):
             self.set_boot_options(image_name, **vendor_specifics)
-            self.save()
             self.reboot(confirm=True)
             self._wait_for_device_reboot(timeout=timeout)
             if not self._image_booted(image_name):

--- a/pyntc/devices/jnpr_device.py
+++ b/pyntc/devices/jnpr_device.py
@@ -189,6 +189,9 @@ class JunosDevice(BaseDevice):
     def get_boot_options(self):
         return self.facts['os_version']
 
+    def install_os(self, image_name, **vendor_specifics):
+        raise NotImplementedError
+
     def open(self):
         if not self.connected:
             self.native.open()

--- a/pyntc/devices/nxos_device.py
+++ b/pyntc/devices/nxos_device.py
@@ -104,10 +104,9 @@ class NXOSDevice(BaseDevice):
         return self.native.get_boot_options()
 
     def install_os(self, image_name, **vendor_specifics):
-        kickstart = vendor_specifics.get("kickstart")
         timeout = vendor_specifics.get("timeout", 3600)
         if not self._image_booted(image_name):
-            self.set_boot_options(image_name, kickstart=kickstart, **vendor_specifics)
+            self.set_boot_options(image_name, **vendor_specifics)
             self._wait_for_device_reboot(timeout=timeout)
             if not self._image_booted(image_name):
                 raise OSInstallError(hostname=self.facts.get("hostname"), desired_boot=image_name)
@@ -149,10 +148,11 @@ class NXOSDevice(BaseDevice):
             raise NTCFileNotFoundError(
                 hostname=self.facts.get("hostname"), file=image_name, dir=file_system
             )
+
         if kickstart is not None:
             if re.search(kickstart, file_system_files) is None:
                 raise NTCFileNotFoundError(
-                    hostname=self.facts.get("hostname"), file=image_name, dir=file_system
+                    hostname=self.facts.get("hostname"), file=kickstart, dir=file_system
                 )
 
             kickstart = file_system + kickstart

--- a/pyntc/devices/nxos_device.py
+++ b/pyntc/devices/nxos_device.py
@@ -12,6 +12,7 @@ from pyntc.errors import (
     CommandListError,
     NTCFileNotFoundError,
     RebootTimeoutError,
+    OSInstallError,
 )
 
 from pynxos.device import Device as NXOSNative
@@ -101,6 +102,20 @@ class NXOSDevice(BaseDevice):
 
     def get_boot_options(self):
         return self.native.get_boot_options()
+
+    def install_os(self, image_name, **vendor_specifics):
+        kickstart = vendor_specifics.get("kickstart")
+        timeout = vendor_specifics.get("timeout", 3600)
+        if not self._image_booted(image_name):
+            self.set_boot_options(image_name, kickstart=kickstart, **vendor_specifics)
+            self._wait_for_device_reboot(timeout=timeout)
+            if not self._image_booted(image_name):
+                raise OSInstallError(hostname=self.facts.get("hostname"), desired_boot=image_name)
+            self.save()
+
+            return True
+
+        return False
 
     def open(self):
         pass


### PR DESCRIPTION
 * `install_os` method added to all but `JunosDevice`.
    - File must be on the device already.
    - Checks that image is not already booted on the device.
    - Ensures device is ready to install image.
    - Saves the config if Device uses config to set boot options (IOS, ASA).
    - Reboots the device if required for OS installation (F5Device does not)
    - Waits for device to reboot or finish installation.
    - Raises `OSInstallError if image is not confirmed installed.
    - Returns `True` if image was installed.
    - Returns `False` if device was already booted on the device.

 * ASADevice, EOSDevice, IOSDevice, NXOSDevice:
    - add `install_os` method.

 * F5Device:
    - Double default timeout value for image installation.
    - add `install_os` method.

* JunosDevice:
    - Set `install_os` method to raise `NotImplementedError`

 * BaseDevice:
    - Update `install_os` docstring with updates required for method to actually be implemented.