### PR TITLE
Implement hardened _wait_for_image_installed() method

### DIFF
--- a/pyntc/devices/f5_device.py
+++ b/pyntc/devices/f5_device.py
@@ -354,8 +354,13 @@ class F5Device(BaseDevice):
 
         while time.time() < end_time:
             time.sleep(20)
-            if self.image_installed(image_name=image_name, volume=volume):
-                return
+            # Avoid race-conditions issues. Newly created volumes _might_ lack
+            # of .version attribute in first seconds of their live.
+            try:
+                if self.image_installed(image_name=image_name, volume=volume):
+                    return
+            except:
+                pass
 
         raise OSInstallError(hostname=self.facts.get("hostname"), desired_boot=volume)
 


### PR DESCRIPTION
This resolves potential race-condition issue as ntc-ansible tests showed:

fatal: [localhost -> localhost]: FAILED! => {"changed": false, "msg": "'<class 'f5.bigip.tm.sys.software.volume.Volume'>' object has no attribute 'version'"}