### PR TITLE
IOSDevice: Update message in exception

### DIFF
--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -353,15 +353,20 @@ class IOSDevice(BaseDevice):
             )
 
         try:
-            self.config_list(['no boot system', 'boot system {0}/{1}'.format(file_system, image_name)])
+            command = "boot system {0}/{1}".format(file_system, image_name)
+            self.config_list(['no boot system', command])
         except CommandError:
             file_system = file_system.replace(':', '')
-            self.config_list(['no boot system', 'boot system {0} {1}'.format(file_system, image_name)])
+            command = "boot system {0} {1}".format(file_system, image_name)
+            self.config_list(['no boot system', command])
 
-        if self.get_boot_options()["sys"] != image_name:
+        new_boot_options = self.get_boot_options()["sys"]
+        if new_boot_options != image_name:
             raise CommandError(
-                command="boot command",
-                message="Setting boot command did not yield expected results",
+                command=command,
+                message="Setting boot command did not yield expected results, found {0}".format(
+                    new_boot_options
+                ),
             )
 
     def show(self, command, expect=False, expect_string=''):


### PR DESCRIPTION
 * set the command used to configure the boot options to a variable and
call variable in `self.config_list()`

 * Set post configuration boot options data to a variable and use that for comparison with what we expect.

 * Update the `CommandError` message to use `command` and `new_boot_options` variables.