### PR TITLE
IOSDevice: Bug fixes for get/set boot options

### DIFF
--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -251,19 +251,22 @@ class IOSDevice(BaseDevice):
 
     def get_boot_options(self):
         # TODO: CREATE A MOCK FOR TESTING THIS FUNCTION
-        boot_path_regex = r'(?:BOOT variable\s+=\s+|BOOT path-list\s+:\s+|boot\s+system\s+\S+\s+)(\S+)(?:;|)\s*'
+        boot_path_regex = r"(?:BOOT variable\s+=\s+(\S+)\s*$|BOOT path-list\s+:\s*(\S+)\s*$)"
         try:
             # Try show bootvar command first
             show_boot_out = self.show('show bootvar')
+            show_boot_out = show_boot_out.split("Boot Variables on next reload", 1)[-1]
         except CommandError:
             try:
                 # Try show boot if previous command was invalid
                 show_boot_out = self.show('show boot')
+                show_boot_out = show_boot_out.split("Boot Variables on next reload", 1)[-1]
             except CommandError:
                 # Default to running config value
                 show_boot_out = self.show('show run | inc boot')
+                boot_path_regex = r"boot\s+system\s+(?:\S+\s+|)(\S+)\s*$"
 
-        match = re.search(boot_path_regex, show_boot_out)
+        match = re.search(boot_path_regex, show_boot_out, re.MULTILINE)
         if match:
             boot_path = match.group(1)
             file_system = self._get_file_system()
@@ -360,6 +363,7 @@ class IOSDevice(BaseDevice):
             command = "boot system {0} {1}".format(file_system, image_name)
             self.config_list(['no boot system', command])
 
+        self.save()
         new_boot_options = self.get_boot_options()["sys"]
         if new_boot_options != image_name:
             raise CommandError(


### PR DESCRIPTION
  * Some Cisco devices do not update the bootvars from `show boot(var)` until the running-config is saved to startup-config

  * Add call to `save` method before validating `set_boot_options`

  * Update `get_boot_options` method to use `re.MULTILINE`