### PR TITLE
NXOSDevice: Update wait time for `set_boot_options`

### DIFF
--- a/pyntc/devices/nxos_device.py
+++ b/pyntc/devices/nxos_device.py
@@ -35,12 +35,13 @@ class NXOSDevice(BaseDevice):
 
         return False
 
-    def _wait_for_device_reboot(self, timeout=3600):
+    def _wait_for_device_reboot(self, timeout=600):
         start = time.time()
         while time.time() - start < timeout:
             try:
-                self.show("show hostname")
-                return
+                self.refresh_facts()
+                if self.facts["uptime"] < 180:
+                    return
             except:
                 pass
 
@@ -142,8 +143,11 @@ class NXOSDevice(BaseDevice):
             kickstart = file_system + kickstart
 
         image_name = file_system + image_name
+        self.native.timeout = 300
+        upgrade_result = self.native.set_boot_options(image_name, kickstart=kickstart)
+        self.native.timeout = 30
 
-        return self.native.set_boot_options(image_name, kickstart=kickstart)
+        return upgrade_result
 
     def set_timeout(self, timeout):
         self.native.timeout = timeout


### PR DESCRIPTION
 * Issue with waiting for device to reboot where the method was getting called before the device was sent into reboot.

 * Issue with issuing install command was taking longer to return than the default timeout value in `self.native`.

 * Change `_wait_for_device_timeout` to check uptime from facts and ensure it is below 3 minutes.

 * Change `set_boot_options` to increase command timeout in `self.native`.