### PR TITLE
Pin junos-eznc

### DIFF
--- a/pyntc/devices/__init__.py
+++ b/pyntc/devices/__init__.py
@@ -5,10 +5,11 @@ device_type stored as a string, and a class subclassed from BaseDevice.
 from .eos_device import EOSDevice
 from .nxos_device import NXOSDevice
 from .ios_device import IOSDevice
-from .jnpr_device import JunosDevice
+from .f5_device import F5Device
 from .asa_device import ASADevice
 from .f5_device import F5Device
 from .base_device import BaseDevice
+from .jnpr_device import JunosDevice
 
 
 supported_devices = {

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
     "f5-sdk",
     "bigsuds",
     "pyeapi",
-    "junos-eznc",
+    "junos-eznc==2.2.1",
     "scp",
 ]
 


### PR DESCRIPTION
junos-eznc breaks f5-sdk package. Quick fix to pin junos-eznc to 2.2.1

See https://github.com/networktocode/ntc-ansible/issues/253 for details