### PR TITLE
Fix call to enable mode on device

### DIFF
--- a/pyntc/__init__.py
+++ b/pyntc/__init__.py
@@ -2,6 +2,7 @@
 """
 
 import os
+import warnings
 
 from .devices import supported_devices
 from .errors import UnsupportedDeviceError, DeviceNameNotFoundError, ConfFileNotFoundError
@@ -15,6 +16,9 @@ __version__ = "0.0.9"
 
 LIB_PATH_ENV_VAR = "PYNTC_CONF"
 LIB_PATH_DEFAULT = "~/.ntc.conf"
+
+
+warnings.simplefilter("default")
 
 
 def ntc_device(device_type, *args, **kwargs):

--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -5,6 +5,8 @@ import os
 import re
 import signal
 import time
+import warnings
+
 
 from netmiko import ConnectHandler
 from netmiko import FileTransfer
@@ -40,7 +42,7 @@ class ASADevice(BaseDevice):
         self.open()
 
     def _enable(self):
-        print("This method will be deprecated; migrate to use the ``enable`` method")
+        warnings.warn("_enable() is deprecated; use enable().", DeprecationWarning)
         self.enable()
 
     def _enter_config(self):

--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -180,6 +180,11 @@ class ASADevice(BaseDevice):
         self.native.exit_config_mode()
 
     def enable(self):
+        """Ensure device is in enable mode.
+
+        Returns:
+            None: Device prompt is set to enable mode.
+        """
         # Netmiko reports enable and config mode as being enabled
         if not self.native.check_enable_mode():
             self.native.enable()

--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -40,12 +40,11 @@ class ASADevice(BaseDevice):
         self.open()
 
     def _enable(self):
-        self.native.exit_config_mode()
-        if not self.native.check_enable_mode():
-            self.native.enable()
+        print("This method will be deprecated; migrate to use the ``enable`` method")
+        self.enable()
 
     def _enter_config(self):
-        self._enable()
+        self.enable()
         self.native.config_mode()
 
     def _file_copy_instance(self, src, dest=None, file_system="flash:"):
@@ -180,13 +179,21 @@ class ASADevice(BaseDevice):
                 raise CommandListError(entered_commands, command, e.cli_error_msg)
         self.native.exit_config_mode()
 
+    def enable(self):
+        # Netmiko reports enable and config mode as being enabled
+        if not self.native.check_enable_mode():
+            self.native.enable()
+        # Ensure device is not in config mode
+        if self.native.check_config_mode():
+            self.native.exit_config_mode()
+
     @property
     def facts(self):
         """Implement this once facts' re-factor is done. """
         return {}
 
     def file_copy(self, src, dest=None, file_system=None):
-        self._enable()
+        self.enable()
         if file_system is None:
             file_system = self._get_file_system()
 
@@ -211,7 +218,7 @@ class ASADevice(BaseDevice):
 
     # TODO: Make this an internal method since exposing file_copy should be sufficient
     def file_copy_remote_exists(self, src, dest=None, file_system=None):
-        self._enable()
+        self.enable()
         if file_system is None:
             file_system = self._get_file_system()
 
@@ -339,11 +346,11 @@ class ASADevice(BaseDevice):
             )
 
     def show(self, command, expect=False, expect_string=""):
-        self._enable()
+        self.enable()
         return self._send_command(command, expect=expect, expect_string=expect_string)
 
     def show_list(self, commands):
-        self._enable()
+        self.enable()
 
         responses = []
         entered_commands = []

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -180,6 +180,11 @@ class IOSDevice(BaseDevice):
         self.native.exit_config_mode()
 
     def enable(self):
+        """Ensure device is in enable mode.
+
+        Returns:
+            None: Device prompt is set to enable mode.
+        """
         # Netmiko reports enable and config mode as being enabled
         if not self.native.check_enable_mode():
             self.native.enable()

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -5,6 +5,7 @@ import signal
 import os
 import re
 import time
+import warnings
 
 from pyntc.templates import get_structured_data
 from pyntc.data_model.converters import convert_dict_by_key
@@ -42,7 +43,7 @@ class IOSDevice(BaseDevice):
         self.open()
 
     def _enable(self):
-        print("This method will be deprecated; migrate to use the ``enable`` method")
+        warnings.warn("_enable() is deprecated; use enable().", DeprecationWarning)
         self.enable()
 
     def _enter_config(self):

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -42,12 +42,11 @@ class IOSDevice(BaseDevice):
         self.open()
 
     def _enable(self):
-        self.native.exit_config_mode()
-        if not self.native.check_enable_mode():
-            self.native.enable()
+        print("This method will be deprecated; migrate to use the ``enable`` method")
+        self.enable()
 
     def _enter_config(self):
-        self._enable()
+        self.enable()
         self.native.config_mode()
 
     def _file_copy_instance(self, src, dest=None, file_system="flash:"):
@@ -180,6 +179,14 @@ class IOSDevice(BaseDevice):
                 raise CommandListError(entered_commands, command, e.cli_error_msg)
         self.native.exit_config_mode()
 
+    def enable(self):
+        # Netmiko reports enable and config mode as being enabled
+        if not self.native.check_enable_mode():
+            self.native.enable()
+        # Ensure device is not in config mode
+        if self.native.check_config_mode():
+            self.native.exit_config_mode()
+
     @property
     def facts(self):
         if self._facts is None:
@@ -204,7 +211,7 @@ class IOSDevice(BaseDevice):
         return self._facts
 
     def file_copy(self, src, dest=None, file_system=None):
-        self._enable()
+        self.enable()
         if file_system is None:
             file_system = self._get_file_system()
 
@@ -229,7 +236,7 @@ class IOSDevice(BaseDevice):
 
     # TODO: Make this an internal method since exposing file_copy should be sufficient
     def file_copy_remote_exists(self, src, dest=None, file_system=None):
-        self._enable()
+        self.enable()
         if file_system is None:
             file_system = self._get_file_system()
 
@@ -376,11 +383,11 @@ class IOSDevice(BaseDevice):
             )
 
     def show(self, command, expect=False, expect_string=""):
-        self._enable()
+        self.enable()
         return self._send_command(command, expect=expect, expect_string=expect_string)
 
     def show_list(self, commands):
-        self._enable()
+        self.enable()
 
         responses = []
         entered_commands = []

--- a/test/unit/test_devices/test_asa_device.py
+++ b/test/unit/test_devices/test_asa_device.py
@@ -1,0 +1,56 @@
+import unittest
+import mock
+import os
+
+from .device_mocks.ios import send_command, send_command_expect
+from pyntc.devices.base_device import RollbackError
+from pyntc.devices import IOSDevice
+from pyntc.devices.ios_device import FileTransferError
+from pyntc.errors import CommandError, CommandListError, NTCFileNotFoundError
+
+
+class TestASADevice(unittest.TestCase):
+    @mock.patch.object(IOSDevice, "open")
+    @mock.patch.object(IOSDevice, "close")
+    @mock.patch("netmiko.cisco.cisco_ios.CiscoIosSSH", autospec=True)
+    def setUp(self, mock_miko, mock_close, mock_open):
+        self.device = IOSDevice("host", "user", "pass")
+
+        mock_miko.send_command_timing.side_effect = send_command
+        mock_miko.send_command_expect.side_effect = send_command_expect
+        self.device.native = mock_miko
+
+    def tearDown(self):
+        # Reset the mock so we don't have transient test effects
+        self.device.native.reset_mock()
+
+    def test_enable_from_disable(self):
+        self.device.native.check_enable_mode.return_value = False
+        self.device.native.check_config_mode.return_value = False
+        self.device.enable()
+        self.device.native.check_enable_mode.assert_called()
+        self.device.native.enable.assert_called()
+        self.device.native.check_config_mode.assert_called()
+        self.device.native.exit_config_mode.assert_not_called()
+
+    def test_enable_from_enable(self):
+        self.device.native.check_enable_mode.return_value = True
+        self.device.native.check_config_mode.return_value = False
+        self.device.enable()
+        self.device.native.check_enable_mode.assert_called()
+        self.device.native.enable.assert_not_called()
+        self.device.native.check_config_mode.assert_called()
+        self.device.native.exit_config_mode.assert_not_called()
+
+    def test_enable_from_config(self):
+        self.device.native.check_enable_mode.return_value = True
+        self.device.native.check_config_mode.return_value = True
+        self.device.enable()
+        self.device.native.check_enable_mode.assert_called()
+        self.device.native.enable.assert_not_called()
+        self.device.native.check_config_mode.assert_called()
+        self.device.native.exit_config_mode.assert_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_devices/test_ios_device.py
+++ b/test/unit/test_devices/test_ios_device.py
@@ -304,6 +304,33 @@ class TestIOSDevice(unittest.TestCase):
         expected = self.device.show("show startup-config")
         self.assertEqual(self.device.startup_config, expected)
 
+    def test_enable_from_disable(self):
+        self.device.native.check_enable_mode.return_value = False
+        self.device.native.check_config_mode.return_value = False
+        self.device.enable()
+        self.device.native.check_enable_mode.assert_called()
+        self.device.native.enable.assert_called()
+        self.device.native.check_config_mode.assert_called()
+        self.device.native.exit_config_mode.assert_not_called()
+
+    def test_enable_from_enable(self):
+        self.device.native.check_enable_mode.return_value = True
+        self.device.native.check_config_mode.return_value = False
+        self.device.enable()
+        self.device.native.check_enable_mode.assert_called()
+        self.device.native.enable.assert_not_called()
+        self.device.native.check_config_mode.assert_called()
+        self.device.native.exit_config_mode.assert_not_called()
+
+    def test_enable_from_config(self):
+        self.device.native.check_enable_mode.return_value = True
+        self.device.native.check_config_mode.return_value = True
+        self.device.enable()
+        self.device.native.check_enable_mode.assert_called()
+        self.device.native.enable.assert_not_called()
+        self.device.native.check_config_mode.assert_called()
+        self.device.native.exit_config_mode.assert_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Deprecates the private method `._enable()` on ASA and iOS devices.
- Creates a new public method `.enable()` which encapsulates the old private method behavior.
- Updates internal calls to `_enable` to use the new public API.
