### PR TITLE
Issue 136: modify send_command on all devices 

### DIFF
--- a/pyntc/devices/aireos_device.py
+++ b/pyntc/devices/aireos_device.py
@@ -945,7 +945,7 @@ class AIREOSDevice(BaseDevice):
                 message="Setting boot command did not yield expected results",
             )
 
-    def show(self, command, expect_string=""):
+    def show(self, command, expect_string=None):
         """
         Send an operational command to the device.
 

--- a/pyntc/devices/aireos_device.py
+++ b/pyntc/devices/aireos_device.py
@@ -130,13 +130,12 @@ class AIREOSDevice(BaseDevice):
 
         return False
 
-    def _send_command(self, command, expect=False, expect_string=""):
+    def _send_command(self, command, expect_string=None):
         """
         Send single command to device.
 
         Args:
             command (str): The command to send to the device.
-            expect (bool): Whether to send a different expect string than normal prompt.
             expect_string (str): The expected prompt after running the command.
 
         Returns:
@@ -154,13 +153,10 @@ class AIREOSDevice(BaseDevice):
             ...
             >>>
         """
-        if expect:
-            if expect_string:
-                response = self.native.send_command_expect(command, expect_string=expect_string)
-            else:
-                response = self.native.send_command_expect(command)
-        else:
+        if expect_string is None:
             response = self.native.send_command_timing(command)
+        else:
+            response = self.native.send_command(command, expect_string=expect_string)
 
         if "Incorrect usage" in response or "Error:" in response:
             raise CommandError(command, response)
@@ -949,13 +945,12 @@ class AIREOSDevice(BaseDevice):
                 message="Setting boot command did not yield expected results",
             )
 
-    def show(self, command, expect=False, expect_string=""):
+    def show(self, command, expect_string=""):
         """
         Send an operational command to the device.
 
         Args:
             command (str): The command to send to the device.
-            expect (bool): Whether to send a different expect string than normal prompt.
             expect_string (str): The expected prompt after running the command.
 
         Returns:
@@ -974,7 +969,7 @@ class AIREOSDevice(BaseDevice):
             >>>
         """
         self.enable()
-        return self._send_command(command, expect=expect, expect_string=expect_string)
+        return self._send_command(command, expect_string=expect_string)
 
     def show_list(self, commands):
         """

--- a/pyntc/devices/aireos_device.py
+++ b/pyntc/devices/aireos_device.py
@@ -977,7 +977,6 @@ class AIREOSDevice(BaseDevice):
 
         Args:
             commands (list): The list of commands to send to the device.
-            expect (bool): Whether to send a different expect string than normal prompt.
             expect_string (str): The expected prompt after running the command.
 
         Returns:

--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -350,7 +350,7 @@ class ASADevice(BaseDevice):
                 message="Setting boot command did not yield expected results",
             )
 
-    def show(self, command, expect_string=""):
+    def show(self, command, expect_string=None):
         self.enable()
         return self._send_command(command, expect_string=expect_string)
 

--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -97,14 +97,11 @@ class ASADevice(BaseDevice):
         except IndexError:
             return {}
 
-    def _send_command(self, command, expect=False, expect_string=""):
-        if expect:
-            if expect_string:
-                response = self.native.send_command_expect(command, expect_string=expect_string)
-            else:
-                response = self.native.send_command_expect(command)
-        else:
+    def _send_command(self, command, expect_string=None):
+        if expect_string is None:
             response = self.native.send_command_timing(command)
+        else:
+            response = self.native.send_command(command, expect_string=expect_string)
 
         if "% " in response or "Error:" in response:
             raise CommandError(command, response)
@@ -312,7 +309,7 @@ class ASADevice(BaseDevice):
 
     @property
     def running_config(self):
-        return self.show("show running-config", expect=True)
+        return self.show("show running-config")
 
     def save(self, filename="startup-config"):
         command = "copy running-config %s" % filename
@@ -353,9 +350,9 @@ class ASADevice(BaseDevice):
                 message="Setting boot command did not yield expected results",
             )
 
-    def show(self, command, expect=False, expect_string=""):
+    def show(self, command, expect_string=""):
         self.enable()
-        return self._send_command(command, expect=expect, expect_string=expect_string)
+        return self._send_command(command, expect_string=expect_string)
 
     def show_list(self, commands):
         self.enable()

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -101,14 +101,11 @@ class IOSDevice(BaseDevice):
 
         return version_data
 
-    def _send_command(self, command, expect=False, expect_string=""):
-        if expect:
-            if expect_string:
-                response = self.native.send_command_expect(command, expect_string=expect_string)
-            else:
-                response = self.native.send_command_expect(command)
-        else:
+    def _send_command(self, command, expect_string=None):
+        if expect_string is None:
             response = self.native.send_command_timing(command)
+        else:
+            response = self.native.send_command(command, expect_string=expect_string)
 
         if "% " in response or "Error:" in response:
             raise CommandError(command, response)
@@ -352,7 +349,7 @@ class IOSDevice(BaseDevice):
 
     @property
     def running_config(self):
-        return self.show("show running-config", expect=True)
+        return self.show("show running-config")
 
     def save(self, filename="startup-config"):
         command = "copy running-config %s" % filename
@@ -391,9 +388,9 @@ class IOSDevice(BaseDevice):
                 message="Setting boot command did not yield expected results, found {0}".format(new_boot_options),
             )
 
-    def show(self, command, expect=False, expect_string=""):
+    def show(self, command, expect_string=None):
         self.enable()
-        return self._send_command(command, expect=expect, expect_string=expect_string)
+        return self._send_command(command, expect_string=expect_string)
 
     def show_list(self, commands):
         self.enable()

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from unittest import mock
 
-from pyntc.devices import AIREOSDevice
+from pyntc.devices import AIREOSDevice, ASADevice
 
 
 def get_side_effects(mock_path, side_effects):
@@ -176,3 +176,39 @@ def mock_path():
     filepath = os.path.abspath(__file__)
     dirpath = os.path.dirname(filepath)
     return f"{dirpath}/test_devices/device_mocks"
+
+
+@pytest.fixture
+def asa_device():
+    with mock.patch("pyntc.devices.asa_device.ConnectHandler") as ch:
+        device = ASADevice("host", "user", "password")
+        device.native = ch
+        yield device
+
+
+@pytest.fixture
+def asa_mock_path(mock_path):
+    return f"{mock_path}/asa"
+
+
+@pytest.fixture
+def asa_send_command(asa_device, asa_mock_path):
+    def _mock(side_effects, existing_device=None, device=asa_device):
+        if existing_device is not None:
+            device = existing_device
+        device.native.send_command.side_effect = get_side_effects(asa_mock_path, side_effects)
+        return device
+
+    return _mock
+
+
+@pytest.fixture
+def asa_send_command_timing(asa_device, asa_mock_path):
+    def _mock(side_effects, existing_device=None, device=asa_device):
+        if existing_device is not None:
+            device = existing_device
+        device.native.send_command_timing.side_effect = get_side_effects(asa_mock_path, side_effects)
+        return device
+
+    return _mock
+

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from unittest import mock
 
-from pyntc.devices import AIREOSDevice, ASADevice
+from pyntc.devices import AIREOSDevice, ASADevice, IOSDevice
 
 
 def get_side_effects(mock_path, side_effects):
@@ -212,3 +212,37 @@ def asa_send_command_timing(asa_device, asa_mock_path):
 
     return _mock
 
+
+@pytest.fixture
+def ios_device():
+    with mock.patch("pyntc.devices.ios_device.ConnectHandler") as ch:
+        device = IOSDevice("host", "user", "password")
+        device.native = ch
+        yield device
+
+
+@pytest.fixture
+def ios_mock_path(mock_path):
+    return f"{mock_path}/ios"
+
+
+@pytest.fixture
+def ios_send_command(ios_device, ios_mock_path):
+    def _mock(side_effects, existing_device=None, device=ios_device):
+        if existing_device is not None:
+            device = existing_device
+        device.native.send_command.side_effect = get_side_effects(ios_mock_path, side_effects)
+        return device
+
+    return _mock
+
+
+@pytest.fixture
+def ios_send_command_timing(ios_device, ios_mock_path):
+    def _mock(side_effects, existing_device=None, device=ios_device):
+        if existing_device is not None:
+            device = existing_device
+        device.native.send_command_timing.side_effect = get_side_effects(ios_mock_path, side_effects)
+        return device
+
+    return _mock

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -135,17 +135,6 @@ def aireos_send_command(aireos_device, aireos_mock_path):
 
 
 @pytest.fixture
-def aireos_send_command_expect(aireos_device, aireos_mock_path):
-    def _mock(side_effects, existing_device=None, device=aireos_device):
-        if existing_device is not None:
-            device = existing_device
-        device.native.send_command_expect.side_effect = get_side_effects(aireos_mock_path, side_effects)
-        return device
-
-    return _mock
-
-
-@pytest.fixture
 def aireos_send_command_timing(aireos_device, aireos_mock_path):
     def _mock(side_effects, existing_device=None, device=aireos_device):
         if existing_device is not None:

--- a/test/unit/test_devices/device_mocks/asa/__init__.py
+++ b/test/unit/test_devices/device_mocks/asa/__init__.py
@@ -24,13 +24,3 @@ def send_command(command, **kwargs):
         response = f.read()
 
     return response
-
-
-def send_command_expect(command, expect_string=None, **kwargs):
-    response = send_command(command)
-
-    if expect_string:
-        if not re.search(expect_string, response):
-            raise IOError("Search pattern never detected.")
-
-    return response

--- a/test/unit/test_devices/device_mocks/asa/__init__.py
+++ b/test/unit/test_devices/device_mocks/asa/__init__.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 

--- a/test/unit/test_devices/device_mocks/asa/send_command_error.txt
+++ b/test/unit/test_devices/device_mocks/asa/send_command_error.txt
@@ -1,0 +1,2 @@
+This is only a test
+% Error  Use the '?' or <TAB> key to list commands.

--- a/test/unit/test_devices/device_mocks/asa/send_command_expect.txt
+++ b/test/unit/test_devices/device_mocks/asa/send_command_expect.txt
@@ -1,0 +1,2 @@
+This is only a test
+Continue?

--- a/test/unit/test_devices/device_mocks/asa/send_command_timing.txt
+++ b/test/unit/test_devices/device_mocks/asa/send_command_timing.txt
@@ -1,0 +1,1 @@
+This is only a test

--- a/test/unit/test_devices/device_mocks/ios/send_command_error.txt
+++ b/test/unit/test_devices/device_mocks/ios/send_command_error.txt
@@ -1,0 +1,2 @@
+This is only a test
+% Error  Use the '?' or <TAB> key to list commands.

--- a/test/unit/test_devices/device_mocks/ios/send_command_expect.txt
+++ b/test/unit/test_devices/device_mocks/ios/send_command_expect.txt
@@ -1,0 +1,2 @@
+This is only a test
+Continue?

--- a/test/unit/test_devices/device_mocks/ios/send_command_timing.txt
+++ b/test/unit/test_devices/device_mocks/ios/send_command_timing.txt
@@ -1,0 +1,1 @@
+This is only a test

--- a/test/unit/test_devices/test_aireos_device.py
+++ b/test/unit/test_devices/test_aireos_device.py
@@ -80,9 +80,9 @@ def test_send_command_timing(aireos_send_command_timing):
 def test_send_command_expect(aireos_send_command_expect):
     command = "send_command_expect"
     device = aireos_send_command_expect([f"{command}.txt"])
-    device._send_command(command, True, expect_string="Continue?")
-    device.native.send_command_expect.assert_called()
-    device.native.send_command_expect.assert_called_with("send_command_expect", expect_string="Continue?")
+    device._send_command(command, expect_string="Continue?")
+    device.native.send_command.assert_called()
+    device.native.send_command.assert_called_with("send_command_expect", expect_string="Continue?")
 
 
 def test_send_command_error(aireos_send_command_timing):
@@ -947,7 +947,7 @@ def test_show(mock_enable, aireos_send_command_timing):
 @mock.patch.object(AIREOSDevice, "enable")
 def test_show_expect(mock_enable, aireos_send_command_expect):
     device = aireos_send_command_expect(["send_command_expect.txt"])
-    data = device.show("send command expect", expect=True, expect_string="Continue?")
+    data = device.show("send command expect", expect_string="Continue?")
     assert data.strip() == "This is only a test\nContinue?"
     device.native.send_command_expect.assert_called()
 

--- a/test/unit/test_devices/test_aireos_device.py
+++ b/test/unit/test_devices/test_aireos_device.py
@@ -77,6 +77,13 @@ def test_send_command_timing(aireos_send_command_timing):
     device.native.send_command_timing.assert_called_with(command)
 
 
+def test_send_command_expect(aireos_send_command_timing):
+    command = "send_command_expect"
+    device = aireos_send_command_timing([f"{command}.txt"])
+    device._send_command(command)
+    device.native.send_command_timing.assert_called_with("send_command_expect")
+
+
 def test_send_command_error(aireos_send_command_timing):
     command = "send_command_error"
     device = aireos_send_command_timing([f"{command}.txt"])

--- a/test/unit/test_devices/test_aireos_device.py
+++ b/test/unit/test_devices/test_aireos_device.py
@@ -77,11 +77,11 @@ def test_send_command_timing(aireos_send_command_timing):
     device.native.send_command_timing.assert_called_with(command)
 
 
-def test_send_command_expect(aireos_send_command_timing):
+def test_send_command_expect(aireos_send_command):
     command = "send_command_expect"
-    device = aireos_send_command_timing([f"{command}.txt"])
-    device._send_command(command)
-    device.native.send_command_timing.assert_called_with("send_command_expect")
+    device = aireos_send_command([f"{command}.txt"])
+    device._send_command(command, expect_string="Continue?")
+    device.native.send_command.assert_called_with("send_command_expect", expect_string="Continue?")
 
 
 def test_send_command_error(aireos_send_command_timing):

--- a/test/unit/test_devices/test_aireos_device.py
+++ b/test/unit/test_devices/test_aireos_device.py
@@ -928,12 +928,12 @@ def test_set_boot_options_error(mock_save, mock_config, aireos_device, aireos_bo
 
 
 @mock.patch.object(AIREOSDevice, "enable")
-def test_show(mock_enable, aireos_send_command):
-    device = aireos_send_command(["send_command_timing.txt"])
+def test_show(mock_enable, aireos_send_command_timing):
+    device = aireos_send_command_timing(["send_command_timing.txt"])
     data = device.show("send command timing")
     assert data.strip() == "This is only a test"
     mock_enable.assert_called()
-    device.native.send_command.assert_called()
+    device.native.send_command_timing.assert_called()
 
 
 @mock.patch.object(AIREOSDevice, "enable")

--- a/test/unit/test_devices/test_aireos_device.py
+++ b/test/unit/test_devices/test_aireos_device.py
@@ -936,20 +936,20 @@ def test_set_boot_options_error(mock_save, mock_config, aireos_device, aireos_bo
 
 
 @mock.patch.object(AIREOSDevice, "enable")
-def test_show(mock_enable, aireos_send_command_timing):
-    device = aireos_send_command_timing(["send_command_timing.txt"])
+def test_show(mock_enable, aireos_send_command):
+    device = aireos_send_command(["send_command_timing.txt"])
     data = device.show("send command timing")
     assert data.strip() == "This is only a test"
     mock_enable.assert_called()
-    device.native.send_command_timing.assert_called()
+    device.native.send_command.assert_called()
 
 
 @mock.patch.object(AIREOSDevice, "enable")
-def test_show_expect(mock_enable, aireos_send_command_expect):
-    device = aireos_send_command_expect(["send_command_expect.txt"])
+def test_show_expect(mock_enable, aireos_send_command):
+    device = aireos_send_command(["send_command_expect.txt"])
     data = device.show("send command expect", expect_string="Continue?")
     assert data.strip() == "This is only a test\nContinue?"
-    device.native.send_command_expect.assert_called()
+    device.native.send_command.assert_called()
 
 
 @mock.patch.object(AIREOSDevice, "enable")

--- a/test/unit/test_devices/test_aireos_device.py
+++ b/test/unit/test_devices/test_aireos_device.py
@@ -77,14 +77,6 @@ def test_send_command_timing(aireos_send_command_timing):
     device.native.send_command_timing.assert_called_with(command)
 
 
-def test_send_command_expect(aireos_send_command_expect):
-    command = "send_command_expect"
-    device = aireos_send_command_expect([f"{command}.txt"])
-    device._send_command(command, expect_string="Continue?")
-    device.native.send_command.assert_called()
-    device.native.send_command.assert_called_with("send_command_expect", expect_string="Continue?")
-
-
 def test_send_command_error(aireos_send_command_timing):
     command = "send_command_error"
     device = aireos_send_command_timing([f"{command}.txt"])

--- a/test/unit/test_devices/test_asa_device.py
+++ b/test/unit/test_devices/test_asa_device.py
@@ -2,7 +2,7 @@ import pytest
 import os
 from unittest import mock
 
-from .device_mocks.asa import send_command, send_command_expect
+from .device_mocks.asa import send_command
 from pyntc.devices import ASADevice
 from pyntc.devices.asa_device import FileTransferError
 from pyntc.errors import CommandError, CommandListError, NTCFileNotFoundError
@@ -31,7 +31,7 @@ class TestASADevice:
 
         self.device = ASADevice("host", "user", "password")
         api.send_command_timing.side_effect = send_command
-        api.send_command_expect.side_effect = send_command_expect
+        api.send_command.side_effect = send_command
         self.device.native = api
         self.count_setup += 1
 
@@ -233,7 +233,7 @@ class TestASADevice:
         self.device.native.send_command_timing.return_value = f"Current BOOT variable = disk0:/{BOOT_IMAGE}"
         boot_options = self.device.boot_options
         assert boot_options == {"sys": BOOT_IMAGE}
-        self.device.native.send_command_timing.assert_called_with("show boot | i BOOT variable")
+        self.device.native.send_command.assert_called_with("show boot | i BOOT variable")
 
     @mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
     def test_boot_options_none(self, mock_boot):

--- a/test/unit/test_devices/test_asa_device.py
+++ b/test/unit/test_devices/test_asa_device.py
@@ -233,7 +233,7 @@ class TestASADevice:
         self.device.native.send_command_timing.return_value = f"Current BOOT variable = disk0:/{BOOT_IMAGE}"
         boot_options = self.device.boot_options
         assert boot_options == {"sys": BOOT_IMAGE}
-        self.device.native.send_command.assert_called_with("show boot | i BOOT variable")
+        self.device.native.send_command_timing.assert_called_with("show boot | i BOOT variable")
 
     @mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
     def test_boot_options_none(self, mock_boot):

--- a/test/unit/test_devices/test_asa_device.py
+++ b/test/unit/test_devices/test_asa_device.py
@@ -302,3 +302,26 @@ class TestASADevice:
     def test_count_teardown(self):
         # This class is reinstantiated in every test, so the counter is reset
         assert self.count_teardown == 0
+
+
+def test_send_command_timing(asa_send_command_timing):
+    command = "send_command_timing"
+    device = asa_send_command_timing([f"{command}.txt"])
+    device._send_command(command)
+    device.native.send_command_timing.assert_called()
+    device.native.send_command_timing.assert_called_with(command)
+
+
+def test_send_command_expect(asa_send_command):
+    command = "send_command_expect"
+    device = asa_send_command([f"{command}.txt"])
+    device._send_command(command, expect_string="Continue?")
+    device.native.send_command.assert_called_with("send_command_expect", expect_string="Continue?")
+
+
+def test_send_command_error(asa_send_command_timing):
+    command = "send_command_error"
+    device = asa_send_command_timing([f"{command}.txt"])
+    with pytest.raises(CommandError):
+        device._send_command(command)
+    device.native.send_command_timing.assert_called()

--- a/test/unit/test_devices/test_ios_device.py
+++ b/test/unit/test_devices/test_ios_device.py
@@ -2,6 +2,8 @@ import unittest
 import mock
 import os
 
+import pytest
+
 from .device_mocks.ios import send_command, send_command_expect
 from pyntc.devices.base_device import RollbackError
 from pyntc.devices import IOSDevice
@@ -344,3 +346,26 @@ class TestIOSDevice(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def test_send_command_timing(ios_send_command_timing):
+    command = "send_command_timing"
+    device = ios_send_command_timing([f"{command}.txt"])
+    device._send_command(command)
+    device.native.send_command_timing.assert_called()
+    device.native.send_command_timing.assert_called_with(command)
+
+
+def test_send_command_expect(ios_send_command):
+    command = "send_command_expect"
+    device = ios_send_command([f"{command}.txt"])
+    device._send_command(command, expect_string="Continue?")
+    device.native.send_command.assert_called_with("send_command_expect", expect_string="Continue?")
+
+
+def test_send_command_error(ios_send_command_timing):
+    command = "send_command_error"
+    device = ios_send_command_timing([f"{command}.txt"])
+    with pytest.raises(CommandError):
+        device._send_command(command)
+    device.native.send_command_timing.assert_called()


### PR DESCRIPTION
- Modify send_command to use expect_string. Only applies to devices: aireos, asa, and ios.
- Delete send_command_expect calls
- Change expect_string default value to None
- Modify unit tests to run with modified send_command not send_command_expect
