### PR TITLE
Adds while loop to dir for 5 tries and tests.

### DIFF
--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -68,13 +68,22 @@ class IOSDevice(BaseDevice):
         Raises:
             FileSystemNotFound: When the module is unable to determine the default file system.
         """
-        raw_data = self.show("dir")
-        try:
-            file_system = re.match(r"\s*.*?(\S+:)", raw_data).group(1)
-        except AttributeError:
-            raise FileSystemNotFoundError(hostname=self.facts.get("hostname"), command="dir")
+        # Set variables to control while loop
+        file_system_not_found = True
+        counter = 0
 
-        return file_system
+        # Attempt to gather file system
+        while file_system_not_found and counter < 5:
+            counter += 1
+            raw_data = self.show("dir")
+            try:
+                file_system = re.match(r"\s*.*?(\S+:)", raw_data).group(1)
+                return file_system
+            except AttributeError:
+                # Allow to continue through the loop
+                continue
+
+        raise FileSystemNotFoundError(hostname=self.facts.get("hostname"), command="dir")
 
     def _image_booted(self, image_name, **vendor_specifics):
         version_data = self.show("show version")

--- a/test/unit/test_devices/test_ios_device.py
+++ b/test/unit/test_devices/test_ios_device.py
@@ -99,6 +99,12 @@ class TestIOSDevice(unittest.TestCase):
         with self.assertRaisesRegex(CommandListError, "show badcommand"):
             self.device.show_list(commands)
 
+    def test_show_dir(self):
+        command = "dir"
+
+        result = self.device.show(command)
+        self.assertIn("c2600-ik9o3s3-mz.122-15.T9.bin", result)
+
     def test_save(self):
         result = self.device.save()
         self.assertTrue(result)


### PR DESCRIPTION
In order to try multiple times on getting the `dir` output, added a while loop and changed the return/raise sections. This should help alleviate issues where the main directory was not able to be parsed.