### PR TITLE
Update show commands

### DIFF
--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -132,11 +132,11 @@ class IOSDevice(BaseDevice):
 
         return version_data
 
-    def _send_command(self, command, expect_string=None):
-        if expect_string is None:
-            response = self.native.send_command_timing(command)
-        else:
-            response = self.native.send_command(command, expect_string=expect_string)
+    def _send_command(self, command, expect_string=""):
+        command_args = {"command": command}
+        if expect_string is not None:
+            command_args["expect_string"] = expect_string
+        response = self.native.send_command(**command_args)
 
         if "% " in response or "Error:" in response:
             raise CommandError(command, response)
@@ -483,9 +483,9 @@ class IOSDevice(BaseDevice):
 
             try:
                 if timer > 0:
-                    first_response = self.show("reload in %d" % timer)
+                    first_response = self.native.send_command_timing("reload in %d" % timer)
                 else:
-                    first_response = self.show("reload")
+                    first_response = self.native.send_command_timing("reload")
 
                 if "System configuration" in first_response:
                     self.native.send_command_timing("no")

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -132,8 +132,8 @@ class IOSDevice(BaseDevice):
 
         return version_data
 
-    def _send_command(self, command, expect_string=""):
-        command_args = {"command": command}
+        def _send_command(self, command, expect_string=""):
+        command_args = {"command_string": command}
         if expect_string is not None:
             command_args["expect_string"] = expect_string
         response = self.native.send_command(**command_args)


### PR DESCRIPTION
This helps to alleviate empty string results on the dir command during the upgrade process. When sending the command dir with send_command_timing() then I would get an empty string. When sending with send_command() then the results came back. This adds command arguments as discussed, moving to send_command. 

Since the send_command_timing was used due to issues with the reload command back several years, I added the send_command_timing to the reload command section.