### PR TITLE
Remove confirm keyword requirement from device reboot

### DIFF
--- a/pyntc/devices/aireos_device.py
+++ b/pyntc/devices/aireos_device.py
@@ -1019,6 +1019,7 @@ class AIREOSDevice(BaseDevice):
             >>> device.reboot()
             >>>
         """
+
         def handler(signum, frame):
             raise RebootSignal("Interrupting after reload")
 

--- a/pyntc/devices/aireos_device.py
+++ b/pyntc/devices/aireos_device.py
@@ -1002,7 +1002,7 @@ class AIREOSDevice(BaseDevice):
             peer_redundancy_state = "disabled"
         return peer_redundancy_state
 
-    def reboot(self, timer=0, controller="self", save_config=True):
+    def reboot(self, timer=0, controller="self", save_config=True, **kwargs):
         """
         Reload the controller or controller pair.
 
@@ -1019,6 +1019,8 @@ class AIREOSDevice(BaseDevice):
             >>> device.reboot()
             >>>
         """
+        if kwargs.get("confirm"):
+            warnings.warn("Passing 'confirm' to reboot method is deprecated.", DeprecationWarning)
 
         def handler(signum, frame):
             raise RebootSignal("Interrupting after reload")

--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -379,7 +379,7 @@ class ASADevice(BaseDevice):
 
         return peer_redundancy_state.lower()
 
-    def reboot(self, timer=0):
+    def reboot(self, timer=0, **kwargs):
         """
         Reload the controller or controller pair.
 
@@ -394,6 +394,8 @@ class ASADevice(BaseDevice):
             >>> device.reboot()
             >>>
         """
+        if kwargs.get("confirm"):
+            warnings.warn("Passing 'confirm' to reboot method is deprecated.", DeprecationWarning)
 
         def handler(signum, frame):
             raise RebootSignal("Interrupting after reload")

--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -394,6 +394,7 @@ class ASADevice(BaseDevice):
             >>> device.reboot()
             >>>
         """
+
         def handler(signum, frame):
             raise RebootSignal("Interrupting after reload")
 

--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -387,7 +387,7 @@ class ASADevice(BaseDevice):
             timer (int, optional): The time to wait before reloading. Defaults to 0.
 
         Raises:
-            RebootSignal: When the device is still unreachable after the timeout period.
+            RebootTimeoutError: When the device is still unreachable after the timeout period.
 
         Example:
             >>> device = ASADevice(**connection_args)

--- a/pyntc/devices/base_device.py
+++ b/pyntc/devices/base_device.py
@@ -302,7 +302,7 @@ class BaseDevice(object):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def reboot(self, timer=0, confirm=False):
+    def reboot(self, timer=0):
         """Reboot the device.
 
         Args:

--- a/pyntc/devices/eos_device.py
+++ b/pyntc/devices/eos_device.py
@@ -342,7 +342,7 @@ class EOSDevice(BaseDevice):
             )
             self._connected = True
 
-    def reboot(self, timer=0):
+    def reboot(self, timer=0, **kwargs):
         """
         Reload the controller or controller pair.
 
@@ -358,6 +358,9 @@ class EOSDevice(BaseDevice):
             >>>
 
         """
+        if kwargs.get("confirm"):
+            warnings.warn("Passing 'confirm' to reboot method is deprecated.", DeprecationWarning)
+
         if timer != 0:
             raise RebootTimerError(self.device_type)
 

--- a/pyntc/devices/eos_device.py
+++ b/pyntc/devices/eos_device.py
@@ -312,7 +312,7 @@ class EOSDevice(BaseDevice):
         timeout = vendor_specifics.get("timeout", 3600)
         if not self._image_booted(image_name):
             self.set_boot_options(image_name, **vendor_specifics)
-            self.reboot(confirm=True)
+            self.reboot()
             self._wait_for_device_reboot(timeout=timeout)
             if not self._image_booted(image_name):
                 raise OSInstallError(hostname=self.hostname, desired_boot=image_name)
@@ -342,14 +342,26 @@ class EOSDevice(BaseDevice):
             )
             self._connected = True
 
-    def reboot(self, confirm=False, timer=0):
+    def reboot(self, timer=0):
+        """
+        Reload the controller or controller pair.
+
+        Args:
+            timer (int, optional): The time to wait before reloading. Defaults to 0.
+
+        Raises:
+            RebootTimeoutError: When the device is still unreachable after the timeout period.
+
+        Example:
+            >>> device = EOSDevice(**connection_args)
+            >>> device.reboot()
+            >>>
+
+        """
         if timer != 0:
             raise RebootTimerError(self.device_type)
 
-        if confirm:
-            self.show("reload now")
-        else:
-            print("Need to confirm reboot with confirm=True")
+        self.show("reload now")
 
     def rollback(self, rollback_to):
         try:

--- a/pyntc/devices/f5_device.py
+++ b/pyntc/devices/f5_device.py
@@ -520,7 +520,7 @@ class F5Device(BaseDevice):
 
         Raises:
             RuntimeError: If device is unreachable after timeout period, raise an error.
-        
+
         Example:
             >>> device = F5Device(**connection_args)
             >>> device.reboot()

--- a/pyntc/devices/f5_device.py
+++ b/pyntc/devices/f5_device.py
@@ -510,19 +510,31 @@ class F5Device(BaseDevice):
     def open(self):
         pass
 
-    def reboot(self, timer=0, confirm=False, volume=None):
-        if confirm:
-            if self._get_active_volume() == volume:
-                volume_name = None
-            else:
-                volume_name = volume
+    def reboot(self, timer=0, volume=None):
+        """
+        Reload the controller or controller pair.
 
-            self._reboot_to_volume(volume_name=volume_name)
+        Args:
+            timer (int, optional): The time to wait before reloading. Defaults to 0.
+            volume (str, optional): Active volume to reboot. Defaults to None.
 
-            if not self._wait_for_device_reboot(volume_name=volume):
-                raise RuntimeError("Reboot to volume {} failed".format(volume))
+        Raises:
+            RuntimeError: If device is unreachable after timeout period, raise an error.
+        
+        Example:
+            >>> device = F5Device(**connection_args)
+            >>> device.reboot()
+            >>>
+        """
+        if self._get_active_volume() == volume:
+            volume_name = None
         else:
-            print("Need to confirm reboot with confirm=True")
+            volume_name = volume
+
+        self._reboot_to_volume(volume_name=volume_name)
+
+        if not self._wait_for_device_reboot(volume_name=volume):
+            raise RuntimeError("Reboot to volume {} failed".format(volume))
 
     def rollback(self, checkpoint_file):
         raise NotImplementedError

--- a/pyntc/devices/f5_device.py
+++ b/pyntc/devices/f5_device.py
@@ -4,6 +4,7 @@ import hashlib
 import os
 import re
 import time
+import warnings
 
 import bigsuds
 import requests
@@ -510,7 +511,7 @@ class F5Device(BaseDevice):
     def open(self):
         pass
 
-    def reboot(self, timer=0, volume=None):
+    def reboot(self, timer=0, volume=None, **kwargs):
         """
         Reload the controller or controller pair.
 
@@ -526,6 +527,9 @@ class F5Device(BaseDevice):
             >>> device.reboot()
             >>>
         """
+        if kwargs.get("confirm"):
+            warnings.warn("Passing 'confirm' to reboot method is deprecated.", DeprecationWarning)
+
         if self._get_active_volume() == volume:
             volume_name = None
         else:

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -696,7 +696,7 @@ class IOSDevice(BaseDevice):
             processor_redundancy_state = "disabled"
         return processor_redundancy_state
 
-    def reboot(self, timer=0):
+    def reboot(self, timer=0, **kwargs):
         """Reboot device.
         Reload the controller or controller pair.
 
@@ -706,7 +706,8 @@ class IOSDevice(BaseDevice):
         Raises:
             ReloadTimeoutError: When the device is still unreachable after the timeout period.
         """
-        # if confirm:
+        if kwargs.get("confirm"):
+            warnings.warn("Passing 'confirm' to reboot method is deprecated.", DeprecationWarning)
 
         def handler(signum, frame):
             raise RebootSignal("Interrupting after reload")

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -577,7 +577,7 @@ class IOSDevice(BaseDevice):
                     # Run install command and reboot device
                     command = f"request platform software package install switch all file {self._get_file_system()}{image_name} auto-copy"
                     self.show(command, delay_factor=install_mode_delay_factor)
-                    self.reboot(confirm=True)
+                    self.reboot()
 
                 else:
                     # Run install command (which reboots the device)
@@ -591,7 +591,7 @@ class IOSDevice(BaseDevice):
                         pass
             else:
                 self.set_boot_options(image_name, **vendor_specifics)
-                self.reboot(confirm=True)
+                self.reboot()
 
             # Wait for the reboot to finish
             self._wait_for_device_reboot(timeout=timeout)
@@ -696,31 +696,40 @@ class IOSDevice(BaseDevice):
             processor_redundancy_state = "disabled"
         return processor_redundancy_state
 
-    def reboot(self, timer=0, confirm=False):
-        if confirm:
+    def reboot(self, timer=0):
+        """Reboot device.
+        Reload the controller or controller pair.
 
-            def handler(signum, frame):
-                raise RebootSignal("Interrupting after reload")
+        Args:
+            timer (int): The time to wait before reloading.
 
-            signal.signal(signal.SIGALRM, handler)
-            signal.alarm(10)
+        Raises:
+            ReloadTimeoutError: When the device is still unreachable after the timeout period.
+        """
+        # if confirm:
 
-            try:
-                if timer > 0:
-                    first_response = self.native.send_command_timing("reload in %d" % timer)
-                else:
-                    first_response = self.native.send_command_timing("reload")
+        def handler(signum, frame):
+            raise RebootSignal("Interrupting after reload")
 
-                if "System configuration" in first_response:
-                    self.native.send_command_timing("no")
+        signal.signal(signal.SIGALRM, handler)
+        signal.alarm(10)
 
-                self.native.send_command_timing("\n")
-            except RebootSignal:
-                signal.alarm(0)
+        try:
+            if timer > 0:
+                first_response = self.native.send_command_timing("reload in %d" % timer)
+            else:
+                first_response = self.native.send_command_timing("reload")
 
+            if "System configuration" in first_response:
+                self.native.send_command_timing("no")
+
+            self.native.send_command_timing("\n")
+        except RebootSignal:
             signal.alarm(0)
-        else:
-            print("Need to confirm reboot with confirm=True")
+
+        signal.alarm(0)
+        # else:
+        #     print("Need to confirm reboot with confirm=True")
 
     @property
     def redundancy_mode(self):

--- a/pyntc/devices/jnpr_device.py
+++ b/pyntc/devices/jnpr_device.py
@@ -256,7 +256,7 @@ class JunosDevice(BaseDevice):
         if not self.connected:
             self.native.open()
 
-    def reboot(self, timer=0):
+    def reboot(self, timer=0, **kwargs):
         """
         Reload the controller or controller pair.
 
@@ -268,6 +268,9 @@ class JunosDevice(BaseDevice):
             >>> device.reboot()
             >>>
         """
+        if kwargs.get("confirm"):
+            warnings.warn("Passing 'confirm' to reboot method is deprecated.", DeprecationWarning)
+
         self.sw = JunosNativeSW(self.native)
         self.sw.reboot(in_min=timer)
 

--- a/pyntc/devices/jnpr_device.py
+++ b/pyntc/devices/jnpr_device.py
@@ -256,12 +256,20 @@ class JunosDevice(BaseDevice):
         if not self.connected:
             self.native.open()
 
-    def reboot(self, timer=0, confirm=False):
+    def reboot(self, timer=0):
+        """
+        Reload the controller or controller pair.
+
+        Args:
+            timer (int, optional): The time to wait before reloading. Defaults to 0.
+
+        Example:
+            >>> device = JunosDevice(**connection_args)
+            >>> device.reboot()
+            >>>
+        """
         self.sw = JunosNativeSW(self.native)
-        if confirm:
-            self.sw.reboot(in_min=timer)
-        else:
-            print("Need to confirm reboot with confirm=True")
+        self.sw.reboot(in_min=timer)
 
     def rollback(self, filename):
         self.native.timeout = 60

--- a/pyntc/devices/nxos_device.py
+++ b/pyntc/devices/nxos_device.py
@@ -166,11 +166,25 @@ class NXOSDevice(BaseDevice):
     def open(self):
         pass
 
-    def reboot(self, confirm=False, timer=0):
+    def reboot(self, timer=0):
+        """
+        Reload the controller or controller pair.
+
+        Args:
+            timer (int, optional): The time to wait before reloading. Defaults to 0.
+
+        Raises:
+            RebootTimerError: When the device is still unreachable after the timeout period.
+
+        Example:
+            >>> device = NXOSDevice(**connection_args)
+            >>> device.reboot()
+            >>
+        """
         if timer != 0:
             raise RebootTimerError(self.device_type)
 
-        self.native.reboot(confirm=confirm)
+        self.native.reboot(confirm=True)
 
     def rollback(self, filename):
         try:

--- a/pyntc/devices/nxos_device.py
+++ b/pyntc/devices/nxos_device.py
@@ -3,6 +3,7 @@
 import os
 import re
 import time
+import warnings
 
 from .base_device import BaseDevice, RollbackError, RebootTimerError, fix_docs
 from pyntc.errors import (
@@ -166,7 +167,7 @@ class NXOSDevice(BaseDevice):
     def open(self):
         pass
 
-    def reboot(self, timer=0):
+    def reboot(self, timer=0, **kwargs):
         """
         Reload the controller or controller pair.
 
@@ -181,6 +182,9 @@ class NXOSDevice(BaseDevice):
             >>> device.reboot()
             >>
         """
+        if kwargs.get("confirm"):
+            warnings.warn("Passing 'confirm' to reboot method is deprecated.", DeprecationWarning)
+
         if timer != 0:
             raise RebootTimerError(self.device_type)
 

--- a/test/unit/test_devices/test_aireos_device.py
+++ b/test/unit/test_devices/test_aireos_device.py
@@ -1177,6 +1177,17 @@ def test_reboot_confirm(mock_save, mock_reboot, aireos_send_command_timing, aire
 
 @mock.patch("pyntc.devices.aireos_device.RebootSignal")
 @mock.patch.object(AIREOSDevice, "save")
+def test_reboot_confirm_deprecation(mock_save, mock_reboot, aireos_send_command_timing, aireos_redundancy_mode_path):
+    device = aireos_send_command_timing(["reset_system_confirm.txt", "reset_system_restart.txt"])
+    with mock.patch(aireos_redundancy_mode_path, new_callable=mock.PropertyMock) as redundnacy_mode:
+        redundnacy_mode.return_value = "sso enabled"
+        device.reboot(confirm=True)
+    device.native.send_command_timing.assert_has_calls([mock.call("reset system self"), mock.call("y")])
+    mock_save.assert_called()
+
+
+@mock.patch("pyntc.devices.aireos_device.RebootSignal")
+@mock.patch.object(AIREOSDevice, "save")
 def test_reboot_confirm_args(mock_save, mock_reboot, aireos_send_command_timing, aireos_redundancy_mode_path):
     device = aireos_send_command_timing(
         ["reset_system_save.txt", "reset_system_confirm.txt", "reset_system_restart.txt"]

--- a/test/unit/test_devices/test_aireos_device.py
+++ b/test/unit/test_devices/test_aireos_device.py
@@ -855,7 +855,7 @@ def test_install_os(
     assert device.install_os(aireos_boot_image) is True
     device._image_booted.assert_has_calls([mock.call(aireos_boot_image)] * 2)
     mock_set_boot_options.assert_has_calls([mock.call(aireos_boot_image)])
-    mock_reboot.assert_called_with(confirm=True, controller="both", save_config=True)
+    mock_reboot.assert_called_with(controller="both", save_config=True)
     mock_peer_redundancy_state.assert_called()
     mock_disable_wlans.assert_not_called()
     mock_enable_wlans.assert_not_called()
@@ -929,7 +929,7 @@ def test_install_os_pass_controller(
 ):
     device = aireos_image_booted([False, True])
     assert device.install_os(aireos_boot_image, controller="self", save_config=False) is True
-    mock_reboot.assert_called_with(confirm=True, controller="self", save_config=False)
+    mock_reboot.assert_called_with(controller="self", save_config=False)
 
 
 @mock.patch.object(AIREOSDevice, "enable_wlans")
@@ -954,7 +954,7 @@ def test_install_os_disable_all_wlans(
     assert device.install_os(aireos_boot_image, disable_wlans="all") is True
     device._image_booted.assert_has_calls([mock.call(aireos_boot_image)] * 2)
     mock_set_boot_options.assert_has_calls([mock.call(aireos_boot_image)])
-    mock_reboot.assert_called_with(confirm=True, controller="both", save_config=True)
+    mock_reboot.assert_called_with(controller="both", save_config=True)
     mock_peer_redundancy_state.assert_called()
     mock_disable_wlans.assert_called_with("all")
     mock_enable_wlans.assert_called_with("all")
@@ -982,7 +982,7 @@ def test_install_os_disable_select_wlans(
     assert device.install_os(aireos_boot_image, disable_wlans=[1, 3, 7]) is True
     device._image_booted.assert_has_calls([mock.call(aireos_boot_image)] * 2)
     mock_set_boot_options.assert_has_calls([mock.call(aireos_boot_image)])
-    mock_reboot.assert_called_with(confirm=True, controller="both", save_config=True)
+    mock_reboot.assert_called_with(controller="both", save_config=True)
     mock_peer_redundancy_state.assert_called()
     mock_disable_wlans.assert_called_with([1, 3, 7])
     mock_enable_wlans.assert_called_with([1, 3, 7])
@@ -1170,7 +1170,7 @@ def test_reboot_confirm(mock_save, mock_reboot, aireos_send_command_timing, aire
     device = aireos_send_command_timing(["reset_system_confirm.txt", "reset_system_restart.txt"])
     with mock.patch(aireos_redundancy_mode_path, new_callable=mock.PropertyMock) as redundnacy_mode:
         redundnacy_mode.return_value = "sso enabled"
-        device.reboot(confirm=True)
+        device.reboot()
     device.native.send_command_timing.assert_has_calls([mock.call("reset system self"), mock.call("y")])
     mock_save.assert_called()
 
@@ -1183,7 +1183,7 @@ def test_reboot_confirm_args(mock_save, mock_reboot, aireos_send_command_timing,
     )
     with mock.patch(aireos_redundancy_mode_path, new_callable=mock.PropertyMock) as redundnacy_mode:
         redundnacy_mode.return_value = "sso enabled"
-        device.reboot(confirm=True, timer="00:00:10", controller="both", save_config=False)
+        device.reboot(timer="00:00:10", controller="both", save_config=False)
     device.native.send_command_timing.assert_has_calls(
         [mock.call("reset system both in 00:00:10"), mock.call("n"), mock.call("y")]
     )
@@ -1196,7 +1196,7 @@ def test_reboot_confirm_standalone(mock_save, mock_reboot, aireos_send_command_t
     device = aireos_send_command_timing(["reset_system_confirm.txt", "reset_system_restart.txt"])
     with mock.patch(aireos_redundancy_mode_path, new_callable=mock.PropertyMock) as redundnacy_mode:
         redundnacy_mode.return_value = "sso disabled"
-        device.reboot(confirm=True)
+        device.reboot()
     device.native.send_command_timing.assert_has_calls([mock.call("reset system"), mock.call("y")])
     mock_save.assert_called()
 
@@ -1211,17 +1211,11 @@ def test_reboot_confirm_standalone_args(
     )
     with mock.patch(aireos_redundancy_mode_path, new_callable=mock.PropertyMock) as redundnacy_mode:
         redundnacy_mode.return_value = "sso disabled"
-        device.reboot(confirm=True, timer="00:00:10", controller="both", save_config=False)
+        device.reboot(timer="00:00:10", controller="both", save_config=False)
     device.native.send_command_timing.assert_has_calls(
         [mock.call("reset system in 00:00:10"), mock.call("n"), mock.call("y")]
     )
     mock_save.assert_not_called()
-
-
-@mock.patch("pyntc.devices.aireos_device.RebootSignal")
-def test_reboot_no_confirm(mock_reboot, aireos_device):
-    aireos_device.reboot(confirm=False)
-    aireos_device.native.send_command_timing.assert_not_called()
 
 
 def test_redundancy_mode_sso(aireos_show):

--- a/test/unit/test_devices/test_asa_device.py
+++ b/test/unit/test_devices/test_asa_device.py
@@ -222,16 +222,12 @@ class TestASADevice:
             self.device.file_copy("source_file")
 
     def test_reboot(self):
-        self.device.reboot(confirm=True)
+        self.device.reboot()
         self.device.native.send_command_timing.assert_any_call("reload")
 
     def test_reboot_with_timer(self):
-        self.device.reboot(confirm=True, timer=5)
+        self.device.reboot(timer=5)
         self.device.native.send_command_timing.assert_any_call("reload in 5")
-
-    def test_reboot_no_confirm(self):
-        self.device.reboot()
-        assert not self.device.native.send_command_timing.called
 
     @mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
     def test_boot_options_dir(self, mock_boot):

--- a/test/unit/test_devices/test_asa_device.py
+++ b/test/unit/test_devices/test_asa_device.py
@@ -229,6 +229,10 @@ class TestASADevice:
         self.device.reboot(timer=5)
         self.device.native.send_command_timing.assert_any_call("reload in 5")
 
+    def test_reboot_confirm_deprecated(self):
+        self.device.reboot(confirm=True)
+        self.device.native.send_command_timing.assert_any_call("reload")
+
     @mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
     def test_boot_options_dir(self, mock_boot):
         self.device.native.send_command_timing.side_effect = None

--- a/test/unit/test_devices/test_eos_device.py
+++ b/test/unit/test_devices/test_eos_device.py
@@ -233,16 +233,12 @@ class TestEOSDevice(unittest.TestCase):
             self.device.file_copy("source_file")
 
     def test_reboot(self):
-        self.device.reboot(confirm=True)
-        self.device.native.enable.assert_called_with(["reload now"], encoding="json")
-
-    def test_reboot_no_confirm(self):
         self.device.reboot()
-        assert not self.device.native.enable.called
+        self.device.native.enable.assert_called_with(["reload now"], encoding="json")
 
     def test_reboot_with_timer(self):
         with self.assertRaises(RebootTimerError):
-            self.device.reboot(confirm=True, timer=3)
+            self.device.reboot(timer=3)
 
     def test_boot_options(self):
         boot_options = self.device.boot_options

--- a/test/unit/test_devices/test_f5_device.py
+++ b/test/unit/test_devices/test_f5_device.py
@@ -136,8 +136,7 @@ class TestF5Device:
         volume = VOLUME
         # skip the wait_for_device_reboot
         with (mock.patch.object(self.device, "_wait_for_device_reboot", return_value=True)):
-            self.device.reboot(confirm=True, volume=volume)
-            # self.device.reboot(confirm=True)
+            self.device.reboot(volume=volume)
 
         # # Check if _get_active_volume worked
         api.tm.sys.software.volumes.get_collection.assert_called()
@@ -151,26 +150,18 @@ class TestF5Device:
 
         # skipping timeout! It's too long!!
         with (mock.patch.object(self.device, "_wait_for_device_reboot", timeout=0)):
-            self.device.reboot(confirm=True, volume=volume)
+            self.device.reboot(volume=volume)
 
         # # Check if _get_active_volume worked
         api.tm.sys.software.volumes.get_collection.assert_called()
         # Check if _reboot_to_volume worked
         api.tm.sys.software.volumes.exec_cmd.assert_called_with("reboot", volume=volume)
 
-    def test_reboot_no_confirm(self):
-        api = self.device.api_handler
-        volume = VOLUME
-
-        self.device.reboot(confirm=False, volume=volume)
-
-        assert not api.tm.sys.software.volumes.exec_cmd.called
-
     def test_reboot_no_volume(self):
         api = self.device.api_handler
 
         with (mock.patch.object(self.device, "_wait_for_device_reboot", return_value=True)):
-            self.device.reboot(confirm=True)
+            self.device.reboot()
 
         # Check if _reboot_to_volume worked
         api.tm.util.bash.exec_cmd.assert_called_with("run", utilCmdArgs='-c "reboot"')

--- a/test/unit/test_devices/test_ios_device.py
+++ b/test/unit/test_devices/test_ios_device.py
@@ -205,16 +205,12 @@ class TestIOSDevice(unittest.TestCase):
         mock_open.assert_not_called()
 
     def test_reboot(self):
-        self.device.reboot(confirm=True)
+        self.device.reboot()
         self.device.native.send_command_timing.assert_any_call("reload")
 
     def test_reboot_with_timer(self):
-        self.device.reboot(confirm=True, timer=5)
+        self.device.reboot(timer=5)
         self.device.native.send_command_timing.assert_any_call("reload in 5")
-
-    def test_reboot_no_confirm(self):
-        self.device.reboot()
-        assert not self.device.native.send_command_timing.called
 
     @mock.patch.object(IOSDevice, "_get_file_system", return_value="bootflash:")
     def test_boot_options_show_bootvar(self, mock_boot):

--- a/test/unit/test_devices/test_jnpr_device.py
+++ b/test/unit/test_devices/test_jnpr_device.py
@@ -199,16 +199,12 @@ class TestJnprDevice(unittest.TestCase):
         mock_scp.assert_called_with(self.device.native)
 
     def test_reboot(self):
-        self.device.reboot(confirm=True)
+        self.device.reboot()
         self.device.sw.reboot.assert_called_with(in_min=0)
 
     def test_reboot_timer(self):
-        self.device.reboot(confirm=True, timer=2)
+        self.device.reboot(timer=2)
         self.device.sw.reboot.assert_called_with(in_min=2)
-
-    def test_reboot_no_confirm(self):
-        self.device.reboot()
-        assert not self.device.sw.reboot.called
 
     @mock.patch("pyntc.devices.jnpr_device.JunosDevice.running_config", new_callable=mock.PropertyMock)
     def test_backup_running_config(self, mock_run):

--- a/test/unit/test_devices/test_nxos_device.py
+++ b/test/unit/test_devices/test_nxos_device.py
@@ -152,16 +152,12 @@ class TestNXOSDevice(unittest.TestCase):
         self.device.native.file_copy.assert_called()
 
     def test_reboot(self):
-        self.device.reboot(confirm=True)
-        self.device.native.reboot.assert_called_with(confirm=True)
-
-    def test_reboot_no_confirm(self):
         self.device.reboot()
-        self.device.native.reboot.assert_called_with(confirm=False)
+        self.device.native.reboot.assert_called_with(confirm=True)
 
     def test_reboot_with_timer(self):
         with self.assertRaises(RebootTimerError):
-            self.device.reboot(confirm=True, timer=3)
+            self.device.reboot(timer=3)
 
     def test_boot_options(self):
         expected = {"sys": "my_sys", "boot": "my_boot"}


### PR DESCRIPTION
- Remove confirm keyword from all devices reboot
- Addresses issue #94 