### PR TITLE
Corrected 'boot_options' regex parsing

### DIFF
--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -242,7 +242,7 @@ class IOSDevice(BaseDevice):
         match = re.search(boot_path_regex, show_boot_out, re.MULTILINE)
         if match:
             boot_path_tuple = match.groups()
-            # The regex match will return a tuple of the value and None
+            # The regex match will return two values: the boot value and None
             # The return order will depend on which side of the `or` is matched in the regex
             boot_path = [value for value in boot_path_tuple if value is not None][0]
             file_system = self._get_file_system()

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -242,6 +242,8 @@ class IOSDevice(BaseDevice):
         match = re.search(boot_path_regex, show_boot_out, re.MULTILINE)
         if match:
             boot_path_tuple = match.groups()
+            # The regex match will return a tuple of the value and None
+            # The return order will depend on which side of the `or` is matched in the regex
             boot_path = [value for value in boot_path_tuple if value is not None][0]
             file_system = self._get_file_system()
             boot_image = boot_path.replace(file_system, "")

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -241,7 +241,8 @@ class IOSDevice(BaseDevice):
 
         match = re.search(boot_path_regex, show_boot_out, re.MULTILINE)
         if match:
-            boot_path = match.group(1)
+            boot_path_tuple = match.groups()
+            boot_path = [value for value in boot_path_tuple if value is not None][0]
             file_system = self._get_file_system()
             boot_image = boot_path.replace(file_system, "")
             boot_image = boot_image.replace("/", "")


### PR DESCRIPTION
Line 244 in 'ios_device.py' only captured data from the first capture group. I updated that to be able to get data from either capture group. 