### PR TITLE
Merge config() and config_list() for eos.

### DIFF
--- a/pyntc/devices/eos_device.py
+++ b/pyntc/devices/eos_device.py
@@ -158,12 +158,12 @@ class EOSDevice(BaseDevice):
             commands (str, list): String with single command, or list with multiple commands.
 
         Raises:
-            CommandListError: Issue with the command list provided.
+            CommandError: Issue with the command provided.
+            CommandListError: Issue with a command in the list provided.
         """
         try:
             self.native.config(commands)
         except EOSCommandError as e:
-            print("this exception")
             if isinstance(commands, str):
                 raise CommandError(commands, e.message)
             raise CommandListError(commands, e.commands[len(e.commands) - 1], e.message)

--- a/pyntc/devices/eos_device.py
+++ b/pyntc/devices/eos_device.py
@@ -150,17 +150,32 @@ class EOSDevice(BaseDevice):
     def close(self):
         pass
 
-    def config(self, command):
-        try:
-            self.config_list([command])
-        except CommandListError as e:
-            raise CommandError(e.command, e.message)
+    def config(self, commands):
+        """Merged config and config_list methods.
 
-    def config_list(self, commands):
+        Args:
+            commands (str, list): String with single command, or list with multiple commands.
+
+        Raises:
+            CommandListError: Issue with the command list provided.
+        """
+        # pyeapi config() method already takes (str, list) and converts it to a list if its a str.
         try:
             self.native.config(commands)
         except EOSCommandError as e:
             raise CommandListError(commands, e.commands[len(e.commands) - 1], e.message)
+
+    # def config(self, command):
+    #     try:
+    #         self.config_list([command])
+    #     except CommandListError as e:
+    #         raise CommandError(e.command, e.message)
+
+    # def config_list(self, commands):
+    #     try:
+    #         self.native.config(commands)
+    #     except EOSCommandError as e:
+    #         raise CommandListError(commands, e.commands[len(e.commands) - 1], e.message)
 
     def enable(self):
         """Ensure device is in enable mode.

--- a/pyntc/devices/eos_device.py
+++ b/pyntc/devices/eos_device.py
@@ -160,21 +160,13 @@ class EOSDevice(BaseDevice):
         Raises:
             CommandListError: Issue with the command list provided.
         """
-        # pyeapi config() method already takes (str, list) and converts it to a list if its a str.
-        # original_command_is_str: bool = isinstance(command, str)
-
-        # if original_command_is_str:
-        #     command = [command]  # type: ignore [list-item]
         try:
             self.native.config(commands)
         except EOSCommandError as e:
+            print("this exception")
+            if isinstance(commands, str):
+                raise CommandError(commands, e.message)
             raise CommandListError(commands, e.commands[len(e.commands) - 1], e.message)
-
-    # def config(self, command):
-    #     try:
-    #         self.config_list([command])
-    #     except CommandListError as e:
-    #         raise CommandError(e.command, e.message)
 
     def config_list(self, commands):
         """Send configuration commands in list format to a device.
@@ -183,15 +175,9 @@ class EOSDevice(BaseDevice):
 
         Args:
             commands (list): List with multiple commands.
-
-        Raises:
-            CommandListError: Issue with the command list provided.
         """
         warnings.warn("config_list() is deprecated; use config().", DeprecationWarning)
-        try:
-            self.native.config(commands)
-        except EOSCommandError as e:
-            raise CommandListError(commands, e.commands[len(e.commands) - 1], e.message)
+        self.config(commands)
 
     def enable(self):
         """Ensure device is in enable mode.

--- a/pyntc/devices/eos_device.py
+++ b/pyntc/devices/eos_device.py
@@ -3,6 +3,7 @@
 import re
 import time
 import os
+import warnings
 
 from pyeapi import connect as eos_connect
 from pyeapi.client import Node as EOSNative
@@ -151,7 +152,7 @@ class EOSDevice(BaseDevice):
         pass
 
     def config(self, commands):
-        """Merged config and config_list methods.
+        """Send configuration commands to a device.
 
         Args:
             commands (str, list): String with single command, or list with multiple commands.
@@ -160,6 +161,10 @@ class EOSDevice(BaseDevice):
             CommandListError: Issue with the command list provided.
         """
         # pyeapi config() method already takes (str, list) and converts it to a list if its a str.
+        # original_command_is_str: bool = isinstance(command, str)
+
+        # if original_command_is_str:
+        #     command = [command]  # type: ignore [list-item]
         try:
             self.native.config(commands)
         except EOSCommandError as e:
@@ -171,11 +176,22 @@ class EOSDevice(BaseDevice):
     #     except CommandListError as e:
     #         raise CommandError(e.command, e.message)
 
-    # def config_list(self, commands):
-    #     try:
-    #         self.native.config(commands)
-    #     except EOSCommandError as e:
-    #         raise CommandListError(commands, e.commands[len(e.commands) - 1], e.message)
+    def config_list(self, commands):
+        """Send configuration commands in list format to a device.
+
+        DEPRECATED - Use the `config` method.
+
+        Args:
+            commands (list): List with multiple commands.
+
+        Raises:
+            CommandListError: Issue with the command list provided.
+        """
+        warnings.warn("config_list() is deprecated; use config().", DeprecationWarning)
+        try:
+            self.native.config(commands)
+        except EOSCommandError as e:
+            raise CommandListError(commands, e.commands[len(e.commands) - 1], e.message)
 
     def enable(self):
         """Ensure device is in enable mode.

--- a/test/unit/test_devices/device_mocks/eos/__init__.py
+++ b/test/unit/test_devices/device_mocks/eos/__init__.py
@@ -29,6 +29,11 @@ def enable(commands, encoding="json"):
 
 
 def config(commands):
+    original_command_is_str: bool = isinstance(commands, str)
+
+    if original_command_is_str:
+        commands = [commands]  # type: ignore [list-item]
+
     responses = []
     executed_commands = []
     for command in commands:

--- a/test/unit/test_devices/test_eos_device.py
+++ b/test/unit/test_devices/test_eos_device.py
@@ -27,21 +27,27 @@ class TestEOSDevice(unittest.TestCase):
         # Reset the mock so we don't have transient test effects
         self.device.native.reset_mock()
 
-    def test_config_as_str(self):
+    def test_config_pass_string(self):
         command = "interface Eth1"
         result = self.device.config(command)
 
         self.assertIsNone(result)
         self.device.native.config.assert_called_with(command)
 
-    def test_config_as_list(self):
+    def test_config_pass_list(self):
         commands = ["interface Eth1", "no shutdown"]
         result = self.device.config(commands)
 
         self.assertIsNone(result)
         self.device.native.config.assert_called_with(commands)
 
-    def test_bad_config_as_str(self):
+    @mock.patch.object(EOSDevice, "config")
+    def test_config_list(self, mock_config):
+        commands = ["interface Eth1", "no shutdown"]
+        self.device.config_list(commands)
+        self.device.config.assert_called_with(commands)
+
+    def test_bad_config_pass_string(self):
         command = "asdf poknw"
         response = "Error [1002]: asdf_poknw failed [None]"
 
@@ -50,7 +56,7 @@ class TestEOSDevice(unittest.TestCase):
         assert err.value.command == command
         assert err.value.cli_error_msg == response
 
-    def test_bad_config_as_list(self):
+    def test_bad_config_pass_list(self):
         commands = ["interface Eth1", "apons"]
         response = [
             "Valid",

--- a/test/unit/test_devices/test_eos_device.py
+++ b/test/unit/test_devices/test_eos_device.py
@@ -41,9 +41,6 @@ class TestEOSDevice(unittest.TestCase):
         self.assertIsNone(result)
         self.device.native.config.assert_called_with(commands)
 
-
-    def test_config_list(self):
-
     def test_bad_config_as_str(self):
         command = "asdf poknw"
         response = "Error [1002]: asdf_poknw failed [None]"

--- a/test/unit/test_devices/test_eos_device.py
+++ b/test/unit/test_devices/test_eos_device.py
@@ -36,7 +36,7 @@ class TestEOSDevice(unittest.TestCase):
     def test_bad_config(self):
         command = "asdf poknw"
 
-        with self.assertRaisesRegex(CommandListError, command[0]):
+        with self.assertRaisesRegex(CommandError, command[0]):
             self.device.config(command)
 
     def test_config_list(self):

--- a/test/unit/test_devices/test_eos_device.py
+++ b/test/unit/test_devices/test_eos_device.py
@@ -31,17 +31,17 @@ class TestEOSDevice(unittest.TestCase):
         result = self.device.config(command)
 
         self.assertIsNone(result)
-        self.device.native.config.assert_called_with([command])
+        self.device.native.config.assert_called_with(command)
 
     def test_bad_config(self):
         command = "asdf poknw"
 
-        with self.assertRaisesRegex(CommandError, command):
+        with self.assertRaisesRegex(CommandListError, command[0]):
             self.device.config(command)
 
     def test_config_list(self):
         commands = ["interface Eth1", "no shutdown"]
-        result = self.device.config_list(commands)
+        result = self.device.config(commands)
 
         self.assertIsNone(result)
         self.device.native.config.assert_called_with(commands)
@@ -50,7 +50,7 @@ class TestEOSDevice(unittest.TestCase):
         commands = ["interface Eth1", "apons"]
 
         with self.assertRaisesRegex(CommandListError, commands[1]):
-            self.device.config_list(commands)
+            self.device.config(commands)
 
     def test_show(self):
         command = "show ip arp"


### PR DESCRIPTION
Add deprecation for config_list() and update config() to handle both str, list of commands.

Did spin up a vEOS and tested.