### PR TITLE
Merge config() and config_list() for Juniper.

### DIFF
--- a/pyntc/devices/jnpr_device.py
+++ b/pyntc/devices/jnpr_device.py
@@ -125,6 +125,7 @@ class JunosDevice(BaseDevice):
 
          Raises:
              ConfigLoadError: Issue with loading the command.
+             CommandError: Issue with the command provided, if its a single command, passed in as a string.
              CommandListError: Issue with a command in the list provided.
         """
         if isinstance(commands, str):

--- a/pyntc/devices/jnpr_device.py
+++ b/pyntc/devices/jnpr_device.py
@@ -134,7 +134,6 @@ class JunosDevice(BaseDevice):
             except ConfigLoadError as e:
                 raise CommandError(commands, e.message)
         else:
-            print("got into list")
             try:
                 for command in commands:
                     self.cu.load(command, format=format)

--- a/pyntc/devices/jnpr_device.py
+++ b/pyntc/devices/jnpr_device.py
@@ -128,13 +128,20 @@ class JunosDevice(BaseDevice):
              CommandListError: Issue with a command in the list provided.
         """
         if isinstance(commands, str):
-            commands = [commands]
-        try:
-            for command in commands:
-                self.cu.load(command, format=format)
-            self.cu.commit()
-        except ConfigLoadError as e:
-            raise CommandListError(commands, command, e.message)
+            try:
+                self.cu.load(commands, format=format)
+                self.cu.commit()
+            except ConfigLoadError as e:
+                raise CommandError(commands, e.message)
+        else:
+            print("got into list")
+            try:
+                for command in commands:
+                    self.cu.load(command, format=format)
+
+                self.cu.commit()
+            except ConfigLoadError as e:
+                raise CommandListError(commands, command, e.message)
 
     def config_list(self, commands, format="set"):
         """Send configuration commands in list format to a device.
@@ -145,7 +152,7 @@ class JunosDevice(BaseDevice):
             commands (list): List with multiple commands.
         """
         warnings.warn("config_list() is deprecated; use config().", DeprecationWarning)
-        self.config(commands, format="set")
+        self.config(commands, format=format)
 
     @property
     def connected(self):

--- a/pyntc/devices/jnpr_device.py
+++ b/pyntc/devices/jnpr_device.py
@@ -139,12 +139,12 @@ class JunosDevice(BaseDevice):
     def config_list(self, commands, format="set"):
         """Send configuration commands in list format to a device.
 
-         DEPRECATED - Use the `config` method.
+        DEPRECATED - Use the `config` method.
 
-         Args:
-             commands (list): List with multiple commands.
-         """
-         warnings.warn("config_list() is deprecated; use config().", DeprecationWarning)
+        Args:
+            commands (list): List with multiple commands.
+        """
+        warnings.warn("config_list() is deprecated; use config().", DeprecationWarning)
         self.config(commands, format="set")
 
     @property

--- a/pyntc/devices/jnpr_device.py
+++ b/pyntc/devices/jnpr_device.py
@@ -3,6 +3,7 @@ import re
 import time
 import hashlib
 from tempfile import NamedTemporaryFile
+import warnings
 
 from jnpr.junos import Device as JunosNativeDevice
 from jnpr.junos.utils.config import Config as JunosNativeConfig
@@ -116,21 +117,35 @@ class JunosDevice(BaseDevice):
         if self.connected:
             self.native.close()
 
-    def config(self, command, format="set"):
-        try:
-            self.cu.load(command, format=format)
-            self.cu.commit()
-        except ConfigLoadError as e:
-            raise CommandError(command, e.message)
+    def config(self, commands, format="set"):
+        """Send configuration commands to a device.
 
-    def config_list(self, commands, format="set"):
+        Args:
+             commands (str, list): String with single command, or list with multiple commands.
+
+         Raises:
+             ConfigLoadError: Issue with loading the command.
+             CommandListError: Issue with a command in the list provided.
+        """
+        if isinstance(commands, str):
+            commands = [commands]
         try:
             for command in commands:
                 self.cu.load(command, format=format)
-
             self.cu.commit()
         except ConfigLoadError as e:
             raise CommandListError(commands, command, e.message)
+
+    def config_list(self, commands, format="set"):
+        """Send configuration commands in list format to a device.
+
+         DEPRECATED - Use the `config` method.
+
+         Args:
+             commands (list): List with multiple commands.
+         """
+         warnings.warn("config_list() is deprecated; use config().", DeprecationWarning)
+        self.config(commands, format="set")
 
     @property
     def connected(self):

--- a/test/unit/test_devices/test_jnpr_device.py
+++ b/test/unit/test_devices/test_jnpr_device.py
@@ -71,13 +71,15 @@ class TestJnprDevice(unittest.TestCase):
         result = self.device.config(commands)
 
         self.assertIsNone(result)
-        self.device.cu.load.assert_called_with(commands, format="set")
+        self.device.cu.load.assert_any_call(commands[0], format="set")
+        self.device.cu.load.assert_any_call(commands[1], format="set")
         self.device.cu.commit.assert_called_with()
 
     @mock.patch.object(JunosDevice, "config")
     def test_config_list(self, mock_config):
-        commands = ["interface Eth1", "no shutdown"]
-        self.device.config_list(commands)
+        commands = ["set interfaces lo0", "set snmp community jason"]
+
+        self.device.config_list(commands, format="set")
         self.device.config.assert_called_with(commands, format="set")
 
     def test_bad_config_pass_string(self):

--- a/test/unit/test_devices/test_jnpr_device.py
+++ b/test/unit/test_devices/test_jnpr_device.py
@@ -69,12 +69,12 @@ class TestJnprDevice(unittest.TestCase):
         command = "asdf poknw"
         self.device.cu.load.side_effect = ConfigLoadError(command)
 
-        with self.assertRaisesRegex(CommandError, command):
+        with self.assertRaisesRegex(CommandListError, command):
             self.device.config(command)
 
     def test_config_list(self):
         commands = ["set interfaces lo0", "set snmp community jason"]
-        result = self.device.config_list(commands)
+        result = self.device.config(commands)
 
         self.assertIsNone(result)
 
@@ -93,7 +93,7 @@ class TestJnprDevice(unittest.TestCase):
         self.device.cu.load.side_effect = load_side_effect
 
         with self.assertRaisesRegex(CommandListError, commands[1]):
-            self.device.config_list(commands)
+            self.device.config(commands)
 
     def test_show(self):
         command = "show configuration snmp"

--- a/test/unit/test_devices/test_jnpr_device.py
+++ b/test/unit/test_devices/test_jnpr_device.py
@@ -71,8 +71,7 @@ class TestJnprDevice(unittest.TestCase):
         result = self.device.config(commands)
 
         self.assertIsNone(result)
-        self.device.cu.load.assert_any_call(commands[0], format="set")
-        self.device.cu.load.assert_any_call(commands[1], format="set")
+        self.device.cu.load.assert_has_calls(mock.call(command, format="set") for command in commands)
         self.device.cu.commit.assert_called_with()
 
     @mock.patch.object(JunosDevice, "config")


### PR DESCRIPTION
Deprecation warning for config_list() and repoint it to config() which now turns str into list, and runs commands through for loop to load them into config.