### PR TITLE
Feature/verifying reload has happened

### DIFF
--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -230,7 +230,10 @@ class IOSDevice(BaseDevice):
         raise RebootTimeoutError(hostname=self.hostname, wait_time=timeout)
 
     def _has_reload_happened_recently(self):
-        return re.search(r"^00:00:0\d:*", self.uptime_string) is not None
+        if re.search(r"^00:00:0\d:*", self.uptime_string) is None:
+            self._uptime_string = None
+            return False
+        return True
 
     def backup_running_config(self, filename):
         """Backup running configuration to filename specified.

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -222,8 +222,8 @@ class IOSDevice(BaseDevice):
         while time.time() - start < timeout:
             try:
                 self.open()
-                self.show("show version")
-                return
+                if self._has_reload_happened_recently():
+                    return
             except:  # noqa E722 # nosec
                 pass
 
@@ -710,11 +710,6 @@ class IOSDevice(BaseDevice):
                     # Set a higher delay factor and send it in
                     try:
                         self.show(command, delay_factor=install_mode_delay_factor)
-                        MAXIMUM_RETRIES = 10
-                        for _ in range(0, MAXIMUM_RETRIES):
-                            if self._has_reload_happened_recently():
-                                break
-                            time.sleep(60)
                     except IOError:
                         pass
                     except CommandError:

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -230,7 +230,7 @@ class IOSDevice(BaseDevice):
         raise RebootTimeoutError(hostname=self.hostname, wait_time=timeout)
 
     def _has_reload_happened_recently(self):
-        return re.search("^00:00:0\d:*", self.uptime_string) is not None
+        return re.search(r"^00:00:0\d:*", self.uptime_string) is not None
 
     def backup_running_config(self, filename):
         """Backup running configuration to filename specified.

--- a/tests/unit/test_devices/test_ios_device.py
+++ b/tests/unit/test_devices/test_ios_device.py
@@ -22,6 +22,15 @@ DEVICE_FACTS = {
     "serial": "",
     "config_register": "0x2102",
 }
+RECENT_UPTIME_DEVICE_FACTS = {
+    "version": "15.1(3)T4",
+    "hostname": "rtr2811",
+    "uptime": "9 minutes",
+    "running_image": "c2800nm-adventerprisek9_ivs_li-mz.151-3.T4.bin",
+    "hardware": "2811",
+    "serial": "",
+    "config_register": "0x2102",
+}
 SHOW_BOOT_VARIABLE = (
     "Current Boot Variables:\n"
     "BOOT variable = flash:/cat3k_caa-universalk9.16.11.03a.SPA.bin;\n\n"
@@ -32,15 +41,8 @@ SHOW_BOOT_VARIABLE = (
     "Boot Mode = DEVICE\n"
     "iPXE Timeout = 0"
 )
-DEVICE_FACTS_BIS = {
-    "version": "15.1(3)T4",
-    "hostname": "rtr2811",
-    "uptime": "9 minutes",
-    "running_image": "c2800nm-adventerprisek9_ivs_li-mz.151-3.T4.bin",
-    "hardware": "2811",
-    "serial": "",
-    "config_register": "0x2102",
-}
+
+
 SHOW_BOOT_PATH_LIST = (
     f"BOOT path-list      : {BOOT_IMAGE}\n"
     "Config file         : flash:/config.text\n"
@@ -95,6 +97,7 @@ class TestIOSDevice(unittest.TestCase):
         result = self.device.save()
         self.assertTrue(result)
         self.device.native.send_command_timing.assert_any_call("copy running-config startup-config")
+
 
     @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
     def test_file_copy_remote_exists(self, mock_ft):
@@ -267,12 +270,14 @@ class TestIOSDevice(unittest.TestCase):
         mock_raw_version_data.return_value = DEVICE_FACTS
         uptime_string = self.device.uptime_string
         assert uptime_string == "04:18:59:00"
+        assert self.device._has_reload_happened_recently() is False
 
     @mock.patch.object(IOSDevice, "_raw_version_data", autospec=True)
     def test_uptime_nine_minutes_string(self, mock_raw_version_data):
-        mock_raw_version_data.return_value = DEVICE_FACTS_BIS
+        mock_raw_version_data.return_value = RECENT_UPTIME_DEVICE_FACTS
         uptime_string = self.device.uptime_string
         assert uptime_string == "00:00:09:00"
+        assert self.device._has_reload_happened_recently() is True
 
     def test_vendor(self):
         vendor = self.device.vendor

--- a/tests/unit/test_devices/test_ios_device.py
+++ b/tests/unit/test_devices/test_ios_device.py
@@ -31,7 +31,15 @@ SHOW_BOOT_VARIABLE = (
     "Boot Mode = DEVICE\n"
     "iPXE Timeout = 0"
 )
-
+DEVICE_FACTS_BIS = {
+    "version": "15.1(3)T4",
+    "hostname": "rtr2811",
+    "uptime": "9 minutes",
+    "running_image": "c2800nm-adventerprisek9_ivs_li-mz.151-3.T4.bin",
+    "hardware": "2811",
+    "serial": "",
+    "config_register": "0x2102",
+}
 SHOW_BOOT_PATH_LIST = (
     f"BOOT path-list      : {BOOT_IMAGE}\n"
     "Config file         : flash:/config.text\n"
@@ -258,6 +266,12 @@ class TestIOSDevice(unittest.TestCase):
         mock_raw_version_data.return_value = DEVICE_FACTS
         uptime_string = self.device.uptime_string
         assert uptime_string == "04:18:59:00"
+
+    @mock.patch.object(IOSDevice, "_raw_version_data", autospec=True)
+    def test_uptime_nine_minutes_string(self, mock_raw_version_data):
+        mock_raw_version_data.return_value = DEVICE_FACTS_BIS
+        uptime_string = self.device.uptime_string
+        assert uptime_string == "00:00:09:00"
 
     def test_vendor(self):
         vendor = self.device.vendor

--- a/tests/unit/test_devices/test_ios_device.py
+++ b/tests/unit/test_devices/test_ios_device.py
@@ -1,6 +1,7 @@
 import unittest
 import mock
 import os
+import time
 
 import pytest
 
@@ -1253,6 +1254,51 @@ def test_install_os_install_mode_fast_cli_state(
     assert actual is True
     assert ios_device.fast_cli == fast_cli_setting
 
+@mock.patch.object(IOSDevice, "_has_reload_happened_recently")
+@mock.patch.object(IOSDevice, "os_version", new_callable=mock.PropertyMock)
+@mock.patch.object(IOSDevice, "_image_booted")
+@mock.patch.object(IOSDevice, "set_boot_options")
+@mock.patch.object(IOSDevice, "show")
+@mock.patch.object(IOSDevice, "_wait_for_device_reboot")
+@mock.patch.object(IOSDevice, "_get_file_system")
+@mock.patch.object(IOSDevice, "reboot")
+@mock.patch.object(IOSDevice, "fast_cli", new_callable=mock.PropertyMock)
+@mock.patch.object(time, "sleep")
+def test_install_os_install_mode_with_retries(
+    mock_sleep,
+    mock_fast_cli,
+    mock_reboot,
+    mock_get_file_system,
+    mock_wait_for_reboot,
+    mock_show,
+    mock_set_boot_options,
+    mock_image_booted,
+    mock_os_version,
+    mock_has_reload_happened_recently,
+    ios_device,
+):
+    image_name = "cat9k_iosxe.16.12.04.SPA.bin"
+    file_system = "flash:"
+    mock_get_file_system.return_value = file_system
+    mock_os_version.return_value = "16.12.03a"
+    mock_has_reload_happened_recently.side_effect = [False, False, True]
+    mock_image_booted.side_effect = [False, True]
+    mock_sleep.return_value = None
+    # Call the install os function
+    actual = ios_device.install_os(image_name, install_mode=True)
+
+    # Check the results
+    mock_set_boot_options.assert_called_with("packages.conf")
+    mock_show.assert_called_with(
+        f"install add file {file_system}{image_name} activate commit prompt-level none", delay_factor=20
+    )
+    mock_reboot.assert_not_called()
+    mock_os_version.assert_called()
+    mock_image_booted.assert_called()
+    mock_wait_for_reboot.assert_called()
+    assert actual is True
+    # Assert that fast_cli value was retrieved, set to Fals, and set back to original value
+    assert mock_fast_cli.call_count == 3
 
 def test_show(ios_send_command):
     command = "show_ip_arp"

--- a/tests/unit/test_devices/test_ios_device.py
+++ b/tests/unit/test_devices/test_ios_device.py
@@ -98,7 +98,6 @@ class TestIOSDevice(unittest.TestCase):
         self.assertTrue(result)
         self.device.native.send_command_timing.assert_any_call("copy running-config startup-config")
 
-
     @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
     def test_file_copy_remote_exists(self, mock_ft):
         self.device.native.send_command.side_effect = None
@@ -1259,6 +1258,7 @@ def test_install_os_install_mode_fast_cli_state(
     assert actual is True
     assert ios_device.fast_cli == fast_cli_setting
 
+
 @mock.patch.object(IOSDevice, "_has_reload_happened_recently")
 @mock.patch.object(IOSDevice, "os_version", new_callable=mock.PropertyMock)
 @mock.patch.object(IOSDevice, "_image_booted")
@@ -1304,6 +1304,7 @@ def test_install_os_install_mode_with_retries(
     assert actual is True
     # Assert that fast_cli value was retrieved, set to Fals, and set back to original value
     assert mock_fast_cli.call_count == 3
+
 
 def test_show(ios_send_command):
     command = "show_ip_arp"

--- a/tests/unit/test_devices/test_ios_device.py
+++ b/tests/unit/test_devices/test_ios_device.py
@@ -1264,7 +1264,6 @@ def test_install_os_install_mode_fast_cli_state(
 @mock.patch.object(IOSDevice, "_image_booted")
 @mock.patch.object(IOSDevice, "set_boot_options")
 @mock.patch.object(IOSDevice, "show")
-@mock.patch.object(IOSDevice, "_wait_for_device_reboot")
 @mock.patch.object(IOSDevice, "_get_file_system")
 @mock.patch.object(IOSDevice, "reboot")
 @mock.patch.object(IOSDevice, "fast_cli", new_callable=mock.PropertyMock)
@@ -1274,7 +1273,6 @@ def test_install_os_install_mode_with_retries(
     mock_fast_cli,
     mock_reboot,
     mock_get_file_system,
-    mock_wait_for_reboot,
     mock_show,
     mock_set_boot_options,
     mock_image_booted,
@@ -1300,7 +1298,6 @@ def test_install_os_install_mode_with_retries(
     mock_reboot.assert_not_called()
     mock_os_version.assert_called()
     mock_image_booted.assert_called()
-    mock_wait_for_reboot.assert_called()
     assert actual is True
     # Assert that fast_cli value was retrieved, set to Fals, and set back to original value
     assert mock_fast_cli.call_count == 3


### PR DESCRIPTION
Checking that indeed reload does not happen fast enough for some devices, I have implemented a slightly rudimentary fix that waits for the reload for ten minutes max.

This should solve https://github.com/networktocode/pyntc/issues/266 or at least, put us in the correct direction. 