### PR TITLE
Fix Arista EOS file copy issues

### DIFF
--- a/pyntc/devices/eos_device.py
+++ b/pyntc/devices/eos_device.py
@@ -73,11 +73,11 @@ class EOSDevice(BaseDevice):
         self._connected = False
         log.init(host=host)
 
-    def _file_copy_instance(self, src, dest=None, file_system="flash:"):
+    def _file_copy_instance(self, src, dest=None, file_system="/mnt/flash"):
         if dest is None:
             dest = os.path.basename(src)
 
-        file_copy = FileTransfer(self.native_ssh, src, dest, file_system=file_system)
+        file_copy = FileTransfer(self.native_ssh, src, dest, file_system="/mnt/flash")
         log.debug("Host %s: File copy instance %s.", self.host, file_copy)
         return file_copy
 
@@ -175,7 +175,7 @@ class EOSDevice(BaseDevice):
             dict: Key is ``sys`` with value being the image on the device.
         """
         image = self.show("show boot-config")["softwareImage"]
-        image = image.replace("flash:", "")
+        image = image.replace("flash:/", "")
         log.debug("Host %s: the boot options are %s", self.host, {"sys": image})
         return {"sys": image}
 
@@ -375,7 +375,7 @@ class EOSDevice(BaseDevice):
             file_copy = self._file_copy_instance(src, dest, file_system=file_system)
 
             try:
-                file_copy.enable_scp()
+                # file_copy.enable_scp()
                 file_copy.establish_scp_conn()
                 file_copy.transfer_file()
                 log.info("Host %s: File %s transferred successfully.", self.host, src)

--- a/pyntc/devices/eos_device.py
+++ b/pyntc/devices/eos_device.py
@@ -74,10 +74,13 @@ class EOSDevice(BaseDevice):
         log.init(host=host)
 
     def _file_copy_instance(self, src, dest=None, file_system="/mnt/flash"):
+        # "flash:" is only valid locally, "/mnt/flash" is used externally
+        if file_system == "flash:":
+            file_system = "/mnt/flash"
         if dest is None:
             dest = os.path.basename(src)
 
-        file_copy = FileTransfer(self.native_ssh, src, dest, file_system="/mnt/flash")
+        file_copy = FileTransfer(self.native_ssh, src, dest, file_system=file_system)
         log.debug("Host %s: File copy instance %s.", self.host, file_copy)
         return file_copy
 

--- a/tests/unit/test_devices/device_mocks/eos/enable_json/show_boot-config
+++ b/tests/unit/test_devices/device_mocks/eos/enable_json/show_boot-config
@@ -2,7 +2,7 @@
     "command": "show boot-config",
     "result": {
         "memTestIterations": 0,
-        "softwareImage": "flash:EOS.swi",
+        "softwareImage": "EOS.swi",
         "abootPassword": "(not set)"
     },
     "encoding": "json"

--- a/tests/unit/test_devices/test_eos_device.py
+++ b/tests/unit/test_devices/test_eos_device.py
@@ -240,7 +240,7 @@ class TestEOSDevice(unittest.TestCase):
         mock_ft.assert_called_with(
             self.device.native_ssh, "path/to/source_file", "source_file", file_system="/mnt/flash"
         )
-        #mock_ft_instance.enable_scp.assert_any_call()
+        # mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()
 
@@ -258,7 +258,7 @@ class TestEOSDevice(unittest.TestCase):
         self.device.file_copy("source_file", "dest_file")
 
         mock_ft.assert_called_with(self.device.native_ssh, "source_file", "dest_file", file_system="/mnt/flash")
-        #mock_ft_instance.enable_scp.assert_any_call()
+        # mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()
 
@@ -288,10 +288,10 @@ class TestEOSDevice(unittest.TestCase):
 
     def test_set_boot_options(self):
         results = [
-            [{"result": {"output": "/mnt/flash"}}],
+            [{"result": {"output": "flash:"}}],
             [{"result": {"output": "new_image.swi"}}],
             [{"result": {}}],
-            [{"result": {"softwareImage": "flash:new_image.swi"}}],
+            [{"result": {"softwareImage": "flash:/new_image.swi"}}],
         ]
         calls = [
             mock.call(["dir"], encoding="text"),

--- a/tests/unit/test_devices/test_eos_device.py
+++ b/tests/unit/test_devices/test_eos_device.py
@@ -237,7 +237,7 @@ class TestEOSDevice(unittest.TestCase):
         mock_ft_instance.check_file_exists.side_effect = [False, True]
         self.device.file_copy("path/to/source_file")
 
-        mock_ft.assert_called_with(self.device.native_ssh, "path/to/source_file", "source_file", file_system="flash:")
+        mock_ft.assert_called_with(self.device.native_ssh, "path/to/source_file", "source_file", file_system="/mnt/flash")
         mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()
@@ -255,7 +255,7 @@ class TestEOSDevice(unittest.TestCase):
         mock_ft_instance.check_file_exists.side_effect = [False, True]
         self.device.file_copy("source_file", "dest_file")
 
-        mock_ft.assert_called_with(self.device.native_ssh, "source_file", "dest_file", file_system="flash:")
+        mock_ft.assert_called_with(self.device.native_ssh, "source_file", "dest_file", file_system="/mnt/flash")
         mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()
@@ -286,7 +286,7 @@ class TestEOSDevice(unittest.TestCase):
 
     def test_set_boot_options(self):
         results = [
-            [{"result": {"output": "flash:"}}],
+            [{"result": {"output": "/mnt/flash"}}],
             [{"result": {"output": "new_image.swi"}}],
             [{"result": {}}],
             [{"result": {"softwareImage": "flash:new_image.swi"}}],

--- a/tests/unit/test_devices/test_eos_device.py
+++ b/tests/unit/test_devices/test_eos_device.py
@@ -237,7 +237,9 @@ class TestEOSDevice(unittest.TestCase):
         mock_ft_instance.check_file_exists.side_effect = [False, True]
         self.device.file_copy("path/to/source_file")
 
-        mock_ft.assert_called_with(self.device.native_ssh, "path/to/source_file", "source_file", file_system="/mnt/flash")
+        mock_ft.assert_called_with(
+            self.device.native_ssh, "path/to/source_file", "source_file", file_system="/mnt/flash"
+        )
         mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()

--- a/tests/unit/test_devices/test_eos_device.py
+++ b/tests/unit/test_devices/test_eos_device.py
@@ -240,7 +240,7 @@ class TestEOSDevice(unittest.TestCase):
         mock_ft.assert_called_with(
             self.device.native_ssh, "path/to/source_file", "source_file", file_system="/mnt/flash"
         )
-        mock_ft_instance.enable_scp.assert_any_call()
+        #mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()
 
@@ -258,7 +258,7 @@ class TestEOSDevice(unittest.TestCase):
         self.device.file_copy("source_file", "dest_file")
 
         mock_ft.assert_called_with(self.device.native_ssh, "source_file", "dest_file", file_system="/mnt/flash")
-        mock_ft_instance.enable_scp.assert_any_call()
+        #mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()
 


### PR DESCRIPTION
Fixes issues that occured when trying to upload files to Arista EOS devices.
- Changed default system file path from `flash:/` to `/mnt/flash/` since files are copied to the latter from external sources.
- Disabled `enable_scp` since it is not implemented for EOS devices
- Fixed parsing for `show boot` command to remove the leading "/"