### PR TITLE
Add file_pull option to Cisco IOS devices

### DIFF
--- a/changes/345.added
+++ b/changes/345.added
@@ -1,0 +1,1 @@
+Added the ability to pull files from within a Cisco IOS device.

--- a/changes/345.added
+++ b/changes/345.added
@@ -1,1 +1,1 @@
-Added the ability to pull files from within a Cisco IOS device.
+Added the ability to download files from within a Cisco IOS device.

--- a/docs/user/lib_getting_started.md
+++ b/docs/user/lib_getting_started.md
@@ -272,7 +272,7 @@ from pyntc.utils.models import FileCopyModel
 >>>
 ```
 
-We recommend setting up the ip client on the device to be able to use this feature. For instance, on a Cisco IOS device you would need to set the source interface for the ip client when using http or https urls.  You can do this with the `config` method:
+Before using this feature you may need to configure a client on the device. For instance, on a Cisco IOS device you would need to set the source interface for the ip http client when using http or https urls.  You can do this with the `config` method:
 
 ```python
 >>> csr1.config('ip http client source-interface GigabitEthernet1')

--- a/docs/user/lib_getting_started.md
+++ b/docs/user/lib_getting_started.md
@@ -250,6 +250,33 @@ interface GigabitEthernet1
 >>>
 ```
 
+#### File Copy with URL
+
+All devices that support file copy also support copying files directly from a URL to the device.  This is useful for larger files like OS images.  To do this, you need to use the `FilePullSpec` data model to specify the source file information and then pass that to the `file_copy` method. Currently only supported on Cisco IOS devices. Tested with ftp, http, https, sftp, and tftp urls.
+
+```python
+from pyntc.utils.models import FilePullSpec
+
+>>> source_file = FilePullSpec(
+...     download_url='http://example.com/newconfig.cfg',
+...     checksum='abc123def456',
+...     hashing_algorithm='md5',
+...     file_name='newconfig.cfg'
+... )
+>>> for device in devices:
+...    device.file_copy(source_file)
+...
+>>>
+```
+
+We recommend setting up the ip client on the device to be able to use this feature. For instance, on a Cisco IOS device you would need to set the source interface for the ip client when using http or https urls.  You can do this with the `config` method:
+
+```python
+>>> csr1.config('ip http client source-interface GigabitEthernet1')
+>>>
+```
+
+
 ### Save Configs
 
 - `save` method

--- a/docs/user/lib_getting_started.md
+++ b/docs/user/lib_getting_started.md
@@ -250,21 +250,24 @@ interface GigabitEthernet1
 >>>
 ```
 
-#### File Copy with URL
+#### Remote File Copy (Download to Device)
 
-All devices that support file copy also support copying files directly from a URL to the device.  This is useful for larger files like OS images.  To do this, you need to use the `FilePullSpec` data model to specify the source file information and then pass that to the `file_copy` method. Currently only supported on Cisco IOS devices. Tested with ftp, http, https, sftp, and tftp urls.
+Some devices support copying files directly from a URL to the device. This is useful for larger files like OS images.  To do this, you need to use the `FileCopyModel` data model to specify the source file information and then pass that to the `remote_file_copy` method. Currently only supported on Cisco IOS devices. Tested with ftp, http, https, sftp, and tftp urls.
+
+- `remote_file_copy` method
 
 ```python
-from pyntc.utils.models import FilePullSpec
+from pyntc.utils.models import FileCopyModel
 
->>> source_file = FilePullSpec(
-...     download_url='http://example.com/newconfig.cfg',
+>>> source_file = FileCopyModel(
+...     download_url='sftp://example.com/newconfig.cfg',
 ...     checksum='abc123def456',
 ...     hashing_algorithm='md5',
-...     file_name='newconfig.cfg'
+...     file_name='newconfig.cfg',
+        vrf='Mgmt-vrf'
 ... )
 >>> for device in devices:
-...    device.file_copy(source_file)
+...    device.remote_file_copy(source_file)
 ...
 >>>
 ```
@@ -275,7 +278,6 @@ We recommend setting up the ip client on the device to be able to use this featu
 >>> csr1.config('ip http client source-interface GigabitEthernet1')
 >>>
 ```
-
 
 ### Save Configs
 

--- a/pyntc/devices/base_device.py
+++ b/pyntc/devices/base_device.py
@@ -298,10 +298,7 @@ class BaseDevice:  # pylint: disable=too-many-instance-attributes,too-many-publi
             (str): The hex digest of the file.
         """
         # Initialize the hash object dynamically
-        try:
-            file_hash = hashlib.new(hashing_algorithm.lower())
-        except ValueError as e:
-            raise ValueError(f"Unsupported hashing algorithm: {hashing_algorithm}") from e
+        file_hash = hashlib.new(hashing_algorithm.lower())
 
         with open(filepath, "rb") as f:
             # Read in chunks to handle large firmware files without RAM spikes
@@ -321,6 +318,11 @@ class BaseDevice:  # pylint: disable=too-many-instance-attributes,too-many-publi
             filename (str): The name of the file to check for on the remote device.
             hashing_algorithm (str): The hashing algorithm to use (default: "md5").
             kwargs (dict): Additional keyword arguments that may be used by subclasses.
+
+        Keyword Args:
+            file_system (str): Supported only for IOS and NXOS. The file system for the
+                remote file. If no file_system is provided, then the ``get_file_system``
+                method is used to determine the correct file system to use.
 
         Returns:
             (bool): True if the checksums match, False otherwise.
@@ -351,12 +353,15 @@ class BaseDevice:  # pylint: disable=too-many-instance-attributes,too-many-publi
             hashing_algorithm (str): The hashing algorithm to use (default: "md5").
             kwargs (dict): Additional keyword arguments that may be used by subclasses.
 
+        Keyword Args:
+            file_system (str): Supported only for IOS and NXOS. The file system for the
+                remote file. If no file_system is provided, then the ``get_file_system``
+                method is used to determine the correct file system to use.
+
         Returns:
             (bool): True if the file is verified successfully, False otherwise.
         """
-        return self.check_file_exists(filename, **kwargs) and self.compare_file_checksum(
-            checksum, filename, hashing_algorithm, **kwargs
-        )
+        raise NotImplementedError
 
     def install_os(self, image_name, **vendor_specifics):
         """Install the OS from specified image_name.

--- a/pyntc/devices/base_device.py
+++ b/pyntc/devices/base_device.py
@@ -221,7 +221,7 @@ class BaseDevice:  # pylint: disable=too-many-instance-attributes,too-many-publi
 
         Keyword Args:
             file_system (str): Supported only for IOS and NXOS. The file system for the
-                remote fle. If no file_system is provided, then the ``get_file_system``
+                remote file. If no file_system is provided, then the ``get_file_system``
                 method is used to determine the correct file system to use.
         """
         raise NotImplementedError
@@ -241,7 +241,7 @@ class BaseDevice:  # pylint: disable=too-many-instance-attributes,too-many-publi
 
         Keyword Args:
             file_system (str): Supported only for IOS and NXOS. The file system for the
-                remote fle. If no file_system is provided, then the ``get_file_system``
+                remote file. If no file_system is provided, then the ``get_file_system``
                 method is used to determine the correct file system to use.
 
         Returns:

--- a/pyntc/devices/base_device.py
+++ b/pyntc/devices/base_device.py
@@ -1,9 +1,11 @@
 """The module contains the base class that all device classes must inherit from."""
 
+import hashlib
 import importlib
 import warnings
 
 from pyntc.errors import FeatureNotFoundError, NTCError
+from pyntc.utils.models import FileCopyModel
 
 
 def fix_docs(cls):
@@ -247,6 +249,114 @@ class BaseDevice:  # pylint: disable=too-many-instance-attributes,too-many-publi
         Returns:
             (bool): True if the remote file exists, False if it doesn't.
         """
+
+    def check_file_exists(self, filename, **kwargs):
+        """Check if a remote file exists by filename.
+
+        Args:
+            filename (str): The name of the file to check for on the remote device.
+            kwargs (dict): Additional keyword arguments that may be used by subclasses.
+
+        Keyword Args:
+            file_system (str): Supported only for IOS and NXOS. The file system for the
+                remote file. If no file_system is provided, then the ``get_file_system``
+                method is used to determine the correct file system to use.
+
+        Returns:
+            (bool): True if the remote file exists, False if it doesn't.
+        """
+        raise NotImplementedError
+
+    def get_remote_checksum(self, filename, hashing_algorithm="md5", **kwargs):
+        """Get the checksum of a remote file.
+
+        Args:
+            filename (str): The name of the file to check for on the remote device.
+            hashing_algorithm (str): The hashing algorithm to use (default: "md5").
+            kwargs (dict): Additional keyword arguments that may be used by subclasses.
+
+        Keyword Args:
+            file_system (str): Supported only for IOS and NXOS. The file system for the
+                remote file. If no file_system is provided, then the ``get_file_system``
+                method is used to determine the correct file system to use.
+
+        Returns:
+            (str): The checksum of the remote file.
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def get_local_checksum(filepath, hashing_algorithm="md5", add_newline=False):
+        """Get the checksum of a local file using a specified algorithm.
+
+        Args:
+            filepath (str): The path to the local file.
+            hashing_algorithm (str): The hashing algorithm to use (e.g., "md5", "sha256").
+            add_newline (bool): Whether to append a newline before final hashing (Some devices may require this).
+
+        Returns:
+            (str): The hex digest of the file.
+        """
+        # Initialize the hash object dynamically
+        try:
+            file_hash = hashlib.new(hashing_algorithm.lower())
+        except ValueError as e:
+            raise ValueError(f"Unsupported hashing algorithm: {hashing_algorithm}") from e
+
+        with open(filepath, "rb") as f:
+            # Read in chunks to handle large firmware files without RAM spikes
+            for chunk in iter(lambda: f.read(4096), b""):
+                file_hash.update(chunk)
+
+        if add_newline:
+            file_hash.update(b"\n")
+
+        return file_hash.hexdigest()
+
+    def compare_file_checksum(self, checksum, filename, hashing_algorithm="md5", **kwargs):
+        """Compare the checksum of a local file with a remote file.
+
+        Args:
+            checksum (str): The checksum of the file.
+            filename (str): The name of the file to check for on the remote device.
+            hashing_algorithm (str): The hashing algorithm to use (default: "md5").
+            kwargs (dict): Additional keyword arguments that may be used by subclasses.
+
+        Returns:
+            (bool): True if the checksums match, False otherwise.
+        """
+        return checksum == self.get_remote_checksum(filename, hashing_algorithm, **kwargs)
+
+    def remote_file_copy(self, src: FileCopyModel = None, dest=None, **kwargs):
+        """Copy a file to a remote device.
+
+        Args:
+            src (FileCopyModel): The source file model.
+            dest (str): The destination file path on the remote device.
+            kwargs (dict): Additional keyword arguments that may be used by subclasses.
+
+        Keyword Args:
+            file_system (str): Supported only for IOS and NXOS. The file system for the
+                remote file. If no file_system is provided, then the ``get_file_system``
+                method is used to determine the correct file system to use.
+        """
+        raise NotImplementedError
+
+    def verify_file(self, checksum, filename, hashing_algorithm="md5", **kwargs):
+        """Verify a file on the remote device by and validate the checksums.
+
+        Args:
+            checksum (str): The checksum of the file.
+            filename (str): The name of the file to check for on the remote device.
+            hashing_algorithm (str): The hashing algorithm to use (default: "md5").
+            kwargs (dict): Additional keyword arguments that may be used by subclasses.
+
+        Returns:
+            (bool): True if the file is verified successfully, False otherwise.
+        """
+        return self.check_file_exists(filename, **kwargs) and self.compare_file_checksum(
+            checksum, filename, hashing_algorithm, **kwargs
+        )
 
     def install_os(self, image_name, **vendor_specifics):
         """Install the OS from specified image_name.

--- a/pyntc/devices/base_device.py
+++ b/pyntc/devices/base_device.py
@@ -343,7 +343,7 @@ class BaseDevice:  # pylint: disable=too-many-instance-attributes,too-many-publi
         raise NotImplementedError
 
     def verify_file(self, checksum, filename, hashing_algorithm="md5", **kwargs):
-        """Verify a file on the remote device by and validate the checksums.
+        """Verify a file on the remote device by confirming the file exists and validate the checksum.
 
         Args:
             checksum (str): The checksum of the file.

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -3,18 +3,13 @@
 import os
 import re
 import time
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
-from netmiko import ConnectHandler
-from netmiko.cisco import CiscoIosFileTransfer
+from netmiko import ConnectHandler, FileTransfer
 from netmiko.exceptions import ReadTimeout
 
-if TYPE_CHECKING:
-    from netmiko.base_connection import BaseConnection
-
-from pyntc import log  # pylint: disable=wrong-import-position
-from pyntc.devices.base_device import BaseDevice, RollbackError, fix_docs  # pylint: disable=wrong-import-position
-from pyntc.errors import (  # pylint: disable=wrong-import-position
+from pyntc import log
+from pyntc.devices.base_device import BaseDevice, RollbackError, fix_docs
+from pyntc.errors import (
     CommandError,
     CommandListError,
     DeviceNotActiveError,
@@ -26,8 +21,8 @@ from pyntc.errors import (  # pylint: disable=wrong-import-position
     RebootTimeoutError,
     SocketClosedError,
 )
-from pyntc.utils import get_structured_data  # pylint: disable=wrong-import-position
-from pyntc.utils.models import FilePullSpec  # pylint: disable=wrong-import-position
+from pyntc.utils import get_structured_data
+from pyntc.utils.models import FileCopyModel
 
 BASIC_FACTS_KM = {"model": "hardware", "os_version": "version", "serial_number": "serial", "hostname": "hostname"}
 RE_SHOW_REDUNDANCY = re.compile(
@@ -40,129 +35,6 @@ RE_REDUNDANCY_OPERATION_MODE = re.compile(r"^\s*Operating\s+Redundancy\s+Mode\s*
 RE_REDUNDANCY_STATE = re.compile(r"^\s*Current\s+Software\s+state\s*=\s*(.+?)\s*$", re.M)
 SHOW_DIR_RETRY_COUNT = 5
 INSTALL_MODE_FILE_NAME = "packages.conf"
-
-
-class FileTransferURLPull(CiscoIosFileTransfer):
-    """Custom FileTransfer class to optionally allow downloading files from a url."""
-
-    # Netmiko's FileTransfer class requires a source_file to exist.
-    # When doing a url pull, the source_file is the FilePullSpec, which doesn't exist on the filesystem,
-    # so we have to override the __init__ method to get around this, and not call super().__init__(), since it assumes the file exists.
-    def __init__(  # pylint: disable=super-init-not-called, too-many-positional-arguments
-        self,
-        ssh_conn: "BaseConnection",
-        source_file: Union[str, "FilePullSpec"],
-        dest_file: str,
-        file_system: Optional[str] = None,
-        direction: str = "put",
-        socket_timeout: float = 10.0,
-        progress: Optional[Callable[..., Any]] = None,
-        progress4: Optional[Callable[..., Any]] = None,
-        hash_supported: bool = True,
-    ) -> None:
-        """Uses Netmiko's FileTransfer class to transfer files to and from the device, but also supports pulling files directly from a URL to the device using the device's own download capabilities."""
-        self.ssh_ctl_chan = ssh_conn
-        self.source_file = source_file
-        self.dest_file = dest_file
-        self.direction = direction
-        self.socket_timeout = socket_timeout
-        self.progress = progress
-        self.progress4 = progress4
-        self.pull_from_url = direction == "url_pull"
-        self.source_sha1 = None
-
-        auto_flag = (
-            "cisco_ios" in ssh_conn.device_type
-            or "cisco_xe" in ssh_conn.device_type
-            or "cisco_xr" in ssh_conn.device_type
-        )
-        if not file_system:
-            if auto_flag:
-                self.file_system = self.ssh_ctl_chan._autodetect_fs()
-            else:
-                raise ValueError("Destination file system not specified")
-        else:
-            self.file_system = file_system
-
-        if direction == "put":
-            self.source_md5 = self.file_md5(source_file) if hash_supported else None
-            self.file_size = os.stat(source_file).st_size
-        elif direction == "get":
-            self.source_md5 = self.remote_md5(remote_file=source_file) if hash_supported else None
-            self.file_size = self.remote_file_size(remote_file=source_file)
-        elif direction == "url_pull":
-            if not isinstance(source_file, FilePullSpec):
-                raise ValueError("When direction is 'url_pull', source_file must be a FilePullSpec instance.")
-            # For url_pull, source_file is the URL and dest_file is the filename to save as on the device
-            if source_file.hashing_algorithm and source_file.hashing_algorithm.lower() not in {"md5", "sha512"}:
-                raise ValueError("When direction is 'url_pull', hashing_algorithm must be either 'md5' or 'sha512'.")
-            self.source_md5 = (
-                source_file.checksum if hash_supported and source_file.hashing_algorithm.lower() == "md5" else None
-            )
-            self.source_sha512 = (
-                source_file.checksum if hash_supported and source_file.hashing_algorithm.lower() == "sha512" else None
-            )
-            self.file_size = source_file.file_size
-            self.direction = (
-                "put"  # FileTransfer only supports put and get, so treat url_pull as put for the transfer process
-            )
-        else:
-            raise ValueError("Invalid direction specified")
-
-    def pull_file(self) -> None:
-        """Download the file from the URL to the device using the device's own download capabilities."""
-        url = self.source_file.clean_url
-        current_prompt = self.ssh_ctl_chan.find_prompt()
-        expect_regex = rf"(Destination filename|{re.escape(current_prompt)}|confirm|Password|Address or name of remote host|Source username|Source filename|yes/no|Are you sure you want to continue connecting)"
-        command = f"copy {url} {self.file_system}{self.dest_file}"
-        # Use VRF specified, unless using http or https, which don't support vrf in the copy command
-        if self.source_file.vrf and self.source_file.scheme not in ["http", "https"]:
-            command = f"{command} vrf {self.source_file.vrf}"
-        output = self.ssh_ctl_chan.send_command(command, expect_string=expect_regex, read_timeout=300)
-        for _ in range(10):
-            if current_prompt in output:
-                return
-            # Assume that the filename and address are sent with the url.
-            if re.search(
-                r"(confirm|Address or name of remote host|Source filename|Destination filename)", output, re.IGNORECASE
-            ):
-                output = self.ssh_ctl_chan.send_command("", expect_string=expect_regex, read_timeout=300)
-            if re.search(r"Password", output, re.IGNORECASE):
-                output = self.ssh_ctl_chan.send_command(
-                    self.source_file.token, expect_string=expect_regex, read_timeout=300, cmd_verify=False
-                )
-            if re.search(r"Source username", output, re.IGNORECASE):
-                output = self.ssh_ctl_chan.send_command(
-                    self.source_file.username, expect_string=expect_regex, read_timeout=300
-                )
-            if re.search(r"yes/no|Are you sure you want to continue connecting", output, re.IGNORECASE):
-                output = self.ssh_ctl_chan.send_command("yes", expect_string=expect_regex, read_timeout=300)
-
-    def transfer_file(self) -> None:
-        """Override the transfer_file method to pull from URL if pull_from_url is True."""
-        if self.pull_from_url:
-            self.pull_file()
-        else:
-            super().transfer_file()
-
-    def remote_sha512(self, base_cmd: str = "verify /sha512", remote_file: Optional[str] = None) -> str:
-        """Calculate the sha512 hash of the file on the device."""
-        if remote_file is None:
-            if self.direction == "put":
-                remote_file = self.dest_file
-            elif self.direction == "get":
-                remote_file = self.source_file
-        remote_sha512_cmd = f"{base_cmd} {self.file_system}/{remote_file}"
-        dest_sha512 = self.ssh_ctl_chan._send_command_str(remote_sha512_cmd, read_timeout=300)  # pylint: disable=protected-access
-        dest_sha512 = self.process_md5(dest_sha512)  # Process MD5 still does what we want for parsing the output.
-        return dest_sha512
-
-    def compare_md5(self) -> bool:
-        """Overload compare_md5 to handle sha512."""
-        if self.source_sha512:
-            dest_sha512 = self.remote_sha512()
-            return self.source_sha512 == dest_sha512
-        return super().compare_md5()
 
 
 @fix_docs
@@ -235,15 +107,10 @@ class IOSDevice(BaseDevice):
 
     def _file_copy_instance(self, src, dest=None, file_system="flash:"):
         """Create a FileTransfer instance for copying a file to the device."""
-        direction = "put"
         if dest is None:
-            if isinstance(src, FilePullSpec):
-                dest = src.file_name
-                direction = "url_pull"
-            else:
-                dest = os.path.basename(src)
+            dest = os.path.basename(src)
 
-        file_copy = FileTransferURLPull(self.native, src, dest, direction=direction, file_system=file_system)
+        file_copy = FileTransfer(self.native, src, dest, file_system=file_system)
         log.debug("Host %s: File copy instance %s.", self.host, file_copy)
         return file_copy
 
@@ -746,6 +613,85 @@ class IOSDevice(BaseDevice):
         log.debug("Host %s: Config register %s", self.host, self._config_register)
         return self._config_register
 
+    def get_remote_checksum(self, filename, hashing_algorithm="md5", file_system=None, **kwargs):
+        """Get the checksum of a remote file.
+
+        Args:
+            filename (str): The name of the file to check for on the remote device.
+            hashing_algorithm (str): The hashing algorithm to use (default: "md5").
+            kwargs (dict): Additional keyword arguments that may be used by subclasses.
+
+        Keyword Args:
+            file_system (str): Supported only for IOS and NXOS. The file system for the
+                remote file. If no file_system is provided, then the ``get_file_system``
+                method is used to determine the correct file system to use.
+
+        Returns:
+            (str): The checksum of the remote file.
+
+        Raises:
+            ValueError: If an unsupported hashing algorithm is provided.
+            CommandError: If there is an error in executing the command to get the remote checksum.
+        """
+        if hashing_algorithm not in {"md5", "sha512"}:
+            raise ValueError("hashing_algorithm must be either 'md5' or 'sha512' for Cisco IOS devices.")
+        if file_system is None:
+            file_system = self._get_file_system()
+        cmd = f"verify /{hashing_algorithm} {file_system}/{filename}"
+        result = self.native.send_command_timing(cmd, read_timeout=300)
+        if match := re.search(r"=\s+(\S+)", result):
+            log.debug(
+                "Host %s: Remote checksum for file %s with hashing algorithm %s is %s.",
+                self.host,
+                filename,
+                hashing_algorithm,
+                match[1],
+            )
+            return match[1]
+        log.error(
+            "Host %s: Unable to get remote checksum for file %s with hashing algorithm %s",
+            self.host,
+            filename,
+            hashing_algorithm,
+        )
+        raise CommandError(
+            cmd, f"Unable to get remote checksum for file {filename} with hashing algorithm {hashing_algorithm}"
+        )
+
+    def check_file_exists(self, filename, file_system=None, **kwargs):
+        """Check if a remote file exists by filename.
+
+        Args:
+            filename (str): The name of the file to check for on the remote device.
+            file_system (str): Supported only for IOS and NXOS. The file system for the
+                remote file. If no file_system is provided, then the ``get_file_system``
+                method is used to determine the correct file system to use.
+            kwargs (dict): Additional keyword arguments that may be used by subclasses.
+
+        Returns:
+            (bool): True if the remote file exists, False if it doesn't.
+
+        Raises:
+            CommandError: If there is an error in executing the command to check if the file exists.
+        """
+        cmd = f"dir {file_system or self._get_file_system()}/{filename}"
+        result = self.native.send_command(cmd, read_timeout=30)
+        print(f"Result: {result}")
+        log.info(
+            "Host %s: Checking if file %s exists on remote with command '%s' and result: %s",
+            self.host,
+            filename,
+            cmd,
+            result,
+        )
+        if re.search(r"No such file|No files found|Path does not exist|Error opening", result):
+            log.debug("Host %s: File %s does not exist on remote.", self.host, filename)
+            return False
+        if re.search(rf"Directory of .*{filename}", result):
+            log.debug("Host %s: File %s exists on remote.", self.host, filename)
+            return True
+        raise CommandError(cmd, f"Unable to determine if file {filename} exists on remote.")
+
     def file_copy(self, src, dest=None, file_system=None):
         """Copy file to device.
 
@@ -763,40 +709,113 @@ class IOSDevice(BaseDevice):
         if file_system is None:
             file_system = self._get_file_system()
 
-        if not self.file_copy_remote_exists(src, dest, file_system):
+        dest = dest or os.path.basename(src)
+        local_checksum = self.get_local_checksum(src)
+        log.debug("Host %s: Local checksum for file %s is %s.", self.host, src, local_checksum)
+
+        if not self.verify_file(local_checksum, dest, file_system=file_system):
             file_copy = self._file_copy_instance(src, dest, file_system=file_system)
             #        if not self.fc.verify_space_available():
             #            raise FileTransferError('Not enough space available.')
 
             try:
-                if not isinstance(src, FilePullSpec):
-                    file_copy.enable_scp()
-                    file_copy.establish_scp_conn()
+                file_copy.enable_scp()
+                file_copy.establish_scp_conn()
                 file_copy.transfer_file()
                 log.info("Host %s: File %s transferred successfully.", self.host, src)
             except OSError as error:
                 # compare hashes
                 if not file_copy.compare_md5():
                     log.error("Host %s: Socket closed error %s", self.host, error)
-                    raise SocketClosedError(message=error)
+                    raise SocketClosedError(message=error) from error
                 log.error("Host %s: OS error  %s", self.host, error)
             except:  # noqa E722
                 log.error("Host %s: File transfer error %s", self.host, FileTransferError.default_message)
                 raise FileTransferError
             finally:
-                if not isinstance(src, FilePullSpec):
-                    file_copy.close_scp_chan()
+                file_copy.close_scp_chan()
 
             # Ensure connection to device is still open after long transfers
             self.open()
 
-            if not self.file_copy_remote_exists(src, dest, file_system):
+            if not self.verify_file(local_checksum, dest, file_system=file_system):
                 log.error(
                     "Host %s: Attempted file copy, but could not validate file existed after transfer %s",
                     self.host,
                     FileTransferError.default_message,
                 )
                 raise FileTransferError
+
+    def remote_file_copy(self, src: FileCopyModel, dest=None, file_system=None, **kwargs):
+        """Copy a file to a remote device.
+
+        Args:
+            src (FileCopyModel): The source file model.
+            dest (str): The destination file path on the remote device.
+            kwargs (dict): Additional keyword arguments that may be used by subclasses.
+
+        Keyword Args:
+            file_system (str): Supported only for IOS and NXOS. The file system for the
+                remote file. If no file_system is provided, then the ``get_file_system``
+                method is used to determine the correct file system to use.
+
+        Raises:
+            TypeError: If src is not an instance of FileCopyModel.
+            FileTransferError: If there is an error during file transfer or if the file cannot be verified after transfer.
+        """
+        if not isinstance(src, FileCopyModel):
+            raise TypeError("src must be an instance of FileCopyModel")
+        if file_system is None:
+            file_system = self._get_file_system()
+        if dest is None:
+            dest = src.file_name
+        if not self.verify_file(src.checksum, dest, hashing_algorithm=src.hashing_algorithm, file_system=file_system):
+            current_prompt = self.native.find_prompt()
+
+            # Define prompt mapping for expected prompts during file copy
+            prompt_answers = {
+                r"Password": src.token,
+                r"Source username": src.username,
+                r"yes/no|Are you sure you want to continue connecting": "yes",
+                r"(confirm|Address or name of remote host|Source filename|Destination filename)": "",  # Press Enter
+            }
+            keys = list(prompt_answers.keys()) + [re.escape(current_prompt)]
+            expect_regex = f"({'|'.join(keys)})"
+
+            command = f"copy {src.clean_url} {file_system}{dest}"
+            if src.vrf and src.scheme not in {"http", "https"}:
+                command = f"{command} vrf {src.vrf}"
+
+            # _send_command currently checks for % and raises an error, but during the file copy
+            # their may be a % warning that does not indicate a failure so we will use send_command directly.
+            output = self.native.send_command(command, expect_string=expect_regex, read_timeout=900)
+
+            while current_prompt not in output:
+                # Check for success message in output to break loop and avoid waiting for next prompt
+                if re.search(r"Copy complete|bytes copied in|File transfer successful", output, re.IGNORECASE):
+                    log.info(
+                        "Host %s: File %s transferred successfully with output: %s", self.host, src.file_name, output
+                    )
+                    break
+                # Check for errors explicitly to avoid infinite loops on failure
+                if re.search(r"(Error|Invalid|Failed|Aborted|denied)", output, re.IGNORECASE):
+                    log.error("Host %s: File transfer error %s", self.host, FileTransferError.default_message)
+                    raise FileTransferError
+                for prompt, answer in prompt_answers.items():
+                    if re.search(prompt, output, re.IGNORECASE):
+                        is_password = "Password" in prompt
+                        output = self.native.send_command(
+                            answer, expect_string=expect_regex, read_timeout=900, cmd_verify=not is_password
+                        )
+                        break  # Exit the for loop and check the new output for the next prompt
+
+        if not self.verify_file(src.checksum, dest, hashing_algorithm=src.hashing_algorithm, file_system=file_system):
+            log.error(
+                "Host %s: Attempted remote file copy, but could not validate file existed after transfer %s",
+                self.host,
+                FileTransferError.default_message,
+            )
+            raise FileTransferError
 
     # TODO: Make this an internal method since exposing file_copy should be sufficient
     def file_copy_remote_exists(self, src, dest=None, file_system=None):

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -1,11 +1,18 @@
 """Module for using a Cisco IOS device over SSH."""
 
+from typing import Callable, Optional, Any, Type, Union
+from typing import TYPE_CHECKING
+import contextlib
 import os
 import re
 import time
 
-from netmiko import ConnectHandler, FileTransfer
+from netmiko import ConnectHandler
+from netmiko.cisco import CiscoIosFileTransfer
 from netmiko.exceptions import ReadTimeout
+
+if TYPE_CHECKING:
+    from netmiko.base_connection import BaseConnection
 
 from pyntc import log
 from pyntc.devices.base_device import BaseDevice, RollbackError, fix_docs
@@ -22,6 +29,7 @@ from pyntc.errors import (
     SocketClosedError,
 )
 from pyntc.utils import get_structured_data
+from pyntc.utils.models import FilePullSpec
 
 BASIC_FACTS_KM = {"model": "hardware", "os_version": "version", "serial_number": "serial", "hostname": "hostname"}
 RE_SHOW_REDUNDANCY = re.compile(
@@ -35,6 +43,117 @@ RE_REDUNDANCY_STATE = re.compile(r"^\s*Current\s+Software\s+state\s*=\s*(.+?)\s*
 SHOW_DIR_RETRY_COUNT = 5
 INSTALL_MODE_FILE_NAME = "packages.conf"
 
+
+class FileTransferURLPull(CiscoIosFileTransfer):
+    """Custom FileTransfer class to optionally allow downloading files from a url."""
+
+    def __init__(
+        self,
+        ssh_conn: "BaseConnection",
+        source_file: Union[str, "FilePullSpec"],
+        dest_file: str,
+        file_system: Optional[str] = None,
+        direction: str = "put",
+        socket_timeout: float = 10.0,
+        progress: Optional[Callable[..., Any]] = None,
+        progress4: Optional[Callable[..., Any]] = None,
+        hash_supported: bool = True,
+    ) -> None:
+        self.ssh_ctl_chan = ssh_conn
+        self.source_file = source_file
+        self.dest_file = dest_file
+        self.direction = direction
+        self.socket_timeout = socket_timeout
+        self.progress = progress
+        self.progress4 = progress4
+        self.pull_from_url = direction == "url_pull"
+        self.source_sha1 = None
+
+        auto_flag = (
+            "cisco_ios" in ssh_conn.device_type
+            or "cisco_xe" in ssh_conn.device_type
+            or "cisco_xr" in ssh_conn.device_type
+        )
+        if not file_system:
+            if auto_flag:
+                self.file_system = self.ssh_ctl_chan._autodetect_fs()
+            else:
+                raise ValueError("Destination file system not specified")
+        else:
+            self.file_system = file_system
+
+        if direction == "put":
+            self.source_md5 = self.file_md5(source_file) if hash_supported else None
+            self.file_size = os.stat(source_file).st_size
+        elif direction == "get":
+            self.source_md5 = (
+                self.remote_md5(remote_file=source_file) if hash_supported else None
+            )
+            self.file_size = self.remote_file_size(remote_file=source_file)
+        elif direction == "url_pull":
+            if not isinstance(source_file, FilePullSpec):
+                raise ValueError("When direction is 'url_pull', source_file must be a FilePullSpec instance.")
+            # For url_pull, source_file is the URL and dest_file is the filename to save as on the device
+            if source_file.hashing_algorithm and source_file.hashing_algorithm.lower() not in {"md5", "sha512"}:
+                raise ValueError("When direction is 'url_pull', hashing_algorithm must be either 'md5' or 'sha512'.")
+            self.source_md5 = source_file.checksum if hash_supported and source_file.hashing_algorithm.lower() == "md5" else None
+            self.source_sha512 = source_file.checksum if hash_supported and source_file.hashing_algorithm.lower() == "sha512" else None
+            self.file_size = source_file.file_size
+            self.direction = "put"  # FileTransfer only supports put and get, so treat url_pull as put for the transfer process
+        else:
+            raise ValueError("Invalid direction specified")
+
+    def pull_file(self) -> None:
+        """Download the file from the URL to the device using the device's own download capabilities."""
+        url = self.source_file.clean_url
+        current_prompt = self.ssh_ctl_chan.find_prompt()
+        expect_regex = rf"(Destination filename|{re.escape(current_prompt)}|confirm|Password|Address or name of remote host|Source username|Source filename|yes/no|Are you sure you want to continue connecting)"
+        command = f"copy {url} {self.file_system}{self.dest_file}"
+        # Use VRF specified, unless using http or https, which don't support vrf in the copy command
+        if self.source_file.vrf and self.source_file.scheme not in ["http", "https"]:
+            command = f"{command} vrf {self.source_file.vrf}"
+        output = self.ssh_ctl_chan.send_command(command, expect_string=expect_regex, read_timeout=300)
+        for _ in range(10):
+            if current_prompt in output:
+                return
+            # Assume that the filename and address are sent with the url.
+            if re.search(r"(confirm|Address or name of remote host|Source filename|Destination filename)", output, re.IGNORECASE):
+                output = self.ssh_ctl_chan.send_command("", expect_string=expect_regex, read_timeout=300)
+            if re.search(r"Password", output, re.IGNORECASE):
+                output = self.ssh_ctl_chan.send_command(self.source_file.token, expect_string=expect_regex, read_timeout=300, cmd_verify=False)
+            if re.search(r"Source username", output, re.IGNORECASE):
+                output = self.ssh_ctl_chan.send_command(self.source_file.username, expect_string=expect_regex, read_timeout=300)
+            if re.search(r"yes/no|Are you sure you want to continue connecting", output, re.IGNORECASE):
+                output = self.ssh_ctl_chan.send_command("yes", expect_string=expect_regex, read_timeout=300)
+
+    def transfer_file(self) -> None:
+        """Override the transfer_file method to pull from URL if pull_from_url is True."""
+        if self.pull_from_url:
+            self.pull_file()
+        else:
+            super().transfer_file()
+
+    def remote_sha512(
+        self, base_cmd: str = "verify /sha512", remote_file: Optional[str] = None
+    ) -> str:
+        """Calculate the sha512 hash of the file on the device."""
+        if remote_file is None:
+            if self.direction == "put":
+                remote_file = self.dest_file
+            elif self.direction == "get":
+                remote_file = self.source_file
+        remote_sha512_cmd = f"{base_cmd} {self.file_system}/{remote_file}"
+        dest_sha512 = self.ssh_ctl_chan._send_command_str(remote_sha512_cmd, read_timeout=300)
+        dest_sha512 = self.process_md5(dest_sha512) # Process MD5 still does what we want for parsing the output.
+        return dest_sha512
+
+    def compare_md5(self) -> bool:
+        """Overload compare_md5 to handle sha512."""
+        if self.source_sha512:
+            dest_sha512 = self.remote_sha512()
+            return self.source_sha512 == dest_sha512
+        else:
+            return super().compare_md5()
 
 @fix_docs
 class IOSDevice(BaseDevice):
@@ -105,10 +224,16 @@ class IOSDevice(BaseDevice):
         log.debug("Host %s: Device entered config mode.", self.host)
 
     def _file_copy_instance(self, src, dest=None, file_system="flash:"):
+        """Create a FileTransfer instance for copying a file to the device."""
+        direction = "put"
         if dest is None:
-            dest = os.path.basename(src)
+            if isinstance(src, FilePullSpec):
+                dest = src.file_name
+                direction = "url_pull"
+            else:
+                dest = os.path.basename(src)
 
-        file_copy = FileTransfer(self.native, src, dest, file_system=file_system)
+        file_copy = FileTransferURLPull(self.native, src, dest, direction=direction, file_system=file_system)
         log.debug("Host %s: File copy instance %s.", self.host, file_copy)
         return file_copy
 
@@ -634,8 +759,9 @@ class IOSDevice(BaseDevice):
             #            raise FileTransferError('Not enough space available.')
 
             try:
-                file_copy.enable_scp()
-                file_copy.establish_scp_conn()
+                if not isinstance(src, FilePullSpec):
+                    file_copy.enable_scp()
+                    file_copy.establish_scp_conn()
                 file_copy.transfer_file()
                 log.info("Host %s: File %s transferred successfully.", self.host, src)
             except OSError as error:
@@ -648,7 +774,8 @@ class IOSDevice(BaseDevice):
                 log.error("Host %s: File transfer error %s", self.host, FileTransferError.default_message)
                 raise FileTransferError
             finally:
-                file_copy.close_scp_chan()
+                if not isinstance(src, FilePullSpec):
+                    file_copy.close_scp_chan()
 
             # Ensure connection to device is still open after long transfers
             self.open()
@@ -663,7 +790,7 @@ class IOSDevice(BaseDevice):
 
     # TODO: Make this an internal method since exposing file_copy should be sufficient
     def file_copy_remote_exists(self, src, dest=None, file_system=None):
-        """Copy file to device.
+        """Check if file exists on remote device.
 
         Args:
             src (str): Source of file.

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -12,9 +12,9 @@ from netmiko.exceptions import ReadTimeout
 if TYPE_CHECKING:
     from netmiko.base_connection import BaseConnection
 
-from pyntc import log
-from pyntc.devices.base_device import BaseDevice, RollbackError, fix_docs
-from pyntc.errors import (
+from pyntc import log  # pylint: disable=wrong-import-position
+from pyntc.devices.base_device import BaseDevice, RollbackError, fix_docs  # pylint: disable=wrong-import-position
+from pyntc.errors import (  # pylint: disable=wrong-import-position
     CommandError,
     CommandListError,
     DeviceNotActiveError,
@@ -26,8 +26,8 @@ from pyntc.errors import (
     RebootTimeoutError,
     SocketClosedError,
 )
-from pyntc.utils import get_structured_data
-from pyntc.utils.models import FilePullSpec
+from pyntc.utils import get_structured_data  # pylint: disable=wrong-import-position
+from pyntc.utils.models import FilePullSpec  # pylint: disable=wrong-import-position
 
 BASIC_FACTS_KM = {"model": "hardware", "os_version": "version", "serial_number": "serial", "hostname": "hostname"}
 RE_SHOW_REDUNDANCY = re.compile(
@@ -45,7 +45,10 @@ INSTALL_MODE_FILE_NAME = "packages.conf"
 class FileTransferURLPull(CiscoIosFileTransfer):
     """Custom FileTransfer class to optionally allow downloading files from a url."""
 
-    def __init__(
+    # Netmiko's FileTransfer class requires a source_file to exist.
+    # When doing a url pull, the source_file is the FilePullSpec, which doesn't exist on the filesystem,
+    # so we have to override the __init__ method to get around this, and not call super().__init__(), since it assumes the file exists.
+    def __init__(  # pylint: disable=super-init-not-called, too-many-positional-arguments
         self,
         ssh_conn: "BaseConnection",
         source_file: Union[str, "FilePullSpec"],
@@ -150,7 +153,7 @@ class FileTransferURLPull(CiscoIosFileTransfer):
             elif self.direction == "get":
                 remote_file = self.source_file
         remote_sha512_cmd = f"{base_cmd} {self.file_system}/{remote_file}"
-        dest_sha512 = self.ssh_ctl_chan._send_command_str(remote_sha512_cmd, read_timeout=300)
+        dest_sha512 = self.ssh_ctl_chan._send_command_str(remote_sha512_cmd, read_timeout=300)  # pylint: disable=protected-access
         dest_sha512 = self.process_md5(dest_sha512)  # Process MD5 still does what we want for parsing the output.
         return dest_sha512
 
@@ -159,8 +162,7 @@ class FileTransferURLPull(CiscoIosFileTransfer):
         if self.source_sha512:
             dest_sha512 = self.remote_sha512()
             return self.source_sha512 == dest_sha512
-        else:
-            return super().compare_md5()
+        return super().compare_md5()
 
 
 @fix_docs

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -809,7 +809,9 @@ class IOSDevice(BaseDevice):
                         )
                         break  # Exit the for loop and check the new output for the next prompt
 
-            if not self.verify_file(src.checksum, dest, hashing_algorithm=src.hashing_algorithm, file_system=file_system):
+            if not self.verify_file(
+                src.checksum, dest, hashing_algorithm=src.hashing_algorithm, file_system=file_system
+            ):
                 log.error(
                     "Host %s: Attempted remote file copy, but could not validate file existed after transfer %s",
                     self.host,

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -809,13 +809,13 @@ class IOSDevice(BaseDevice):
                         )
                         break  # Exit the for loop and check the new output for the next prompt
 
-        if not self.verify_file(src.checksum, dest, hashing_algorithm=src.hashing_algorithm, file_system=file_system):
-            log.error(
-                "Host %s: Attempted remote file copy, but could not validate file existed after transfer %s",
-                self.host,
-                FileTransferError.default_message,
-            )
-            raise FileTransferError
+            if not self.verify_file(src.checksum, dest, hashing_algorithm=src.hashing_algorithm, file_system=file_system):
+                log.error(
+                    "Host %s: Attempted remote file copy, but could not validate file existed after transfer %s",
+                    self.host,
+                    FileTransferError.default_message,
+                )
+                raise FileTransferError
 
     # TODO: Make this an internal method since exposing file_copy should be sufficient
     def file_copy_remote_exists(self, src, dest=None, file_system=None):

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -618,7 +618,7 @@ class IOSDevice(BaseDevice):
 
         Args:
             filename (str): The name of the file to check for on the remote device.
-            hashing_algorithm (str): The hashing algorithm to use (default: "md5").
+            hashing_algorithm (str): The hashing algorithm to use. Valid choices are "md5" and "sha512" (default: "md5").
             kwargs (dict): Additional keyword arguments that may be used by subclasses.
 
         Keyword Args:
@@ -787,7 +787,7 @@ class IOSDevice(BaseDevice):
                 command = f"{command} vrf {src.vrf}"
 
             # _send_command currently checks for % and raises an error, but during the file copy
-            # their may be a % warning that does not indicate a failure so we will use send_command directly.
+            # there may be a % warning that does not indicate a failure so we will use send_command directly.
             output = self.native.send_command(command, expect_string=expect_regex, read_timeout=900)
 
             while current_prompt not in output:

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -613,15 +613,12 @@ class IOSDevice(BaseDevice):
         log.debug("Host %s: Config register %s", self.host, self._config_register)
         return self._config_register
 
-    def get_remote_checksum(self, filename, hashing_algorithm="md5", file_system=None, **kwargs):
+    def get_remote_checksum(self, filename, hashing_algorithm="md5", file_system=None):
         """Get the checksum of a remote file.
 
         Args:
             filename (str): The name of the file to check for on the remote device.
             hashing_algorithm (str): The hashing algorithm to use (default: "md5").
-            kwargs (dict): Additional keyword arguments that may be used by subclasses.
-
-        Keyword Args:
             file_system (str): Supported only for IOS and NXOS. The file system for the
                 remote file. If no file_system is provided, then the ``get_file_system``
                 method is used to determine the correct file system to use.
@@ -639,14 +636,17 @@ class IOSDevice(BaseDevice):
             file_system = self._get_file_system()
         cmd = f"verify /{hashing_algorithm} {file_system}/{filename}"
         result = self.native.send_command_timing(cmd, read_timeout=300)
-        if match := re.search(r"=\s+(\S+)", result):
-            log.debug(
-                "Host %s: Remote checksum for file %s with hashing algorithm %s is %s.",
-                self.host,
-                filename,
-                hashing_algorithm,
-                match[1],
-            )
+
+        patterns = [r"=\s+(\S+)", r"^([a-fA-F0-9]+)$"]
+        for pattern in patterns:
+            if match := re.search(pattern, result):
+                log.debug(
+                    "Host %s: Remote checksum for file %s with hashing algorithm %s is %s.",
+                    self.host,
+                    filename,
+                    hashing_algorithm,
+                    match[1],
+                )
             return match[1]
         log.error(
             "Host %s: Unable to get remote checksum for file %s with hashing algorithm %s",
@@ -658,7 +658,7 @@ class IOSDevice(BaseDevice):
             cmd, f"Unable to get remote checksum for file {filename} with hashing algorithm {hashing_algorithm}"
         )
 
-    def check_file_exists(self, filename, file_system=None, **kwargs):
+    def check_file_exists(self, filename, file_system=None):
         """Check if a remote file exists by filename.
 
         Args:
@@ -666,7 +666,6 @@ class IOSDevice(BaseDevice):
             file_system (str): Supported only for IOS and NXOS. The file system for the
                 remote file. If no file_system is provided, then the ``get_file_system``
                 method is used to determine the correct file system to use.
-            kwargs (dict): Additional keyword arguments that may be used by subclasses.
 
         Returns:
             (bool): True if the remote file exists, False if it doesn't.
@@ -676,8 +675,7 @@ class IOSDevice(BaseDevice):
         """
         cmd = f"dir {file_system or self._get_file_system()}/{filename}"
         result = self.native.send_command(cmd, read_timeout=30)
-        print(f"Result: {result}")
-        log.info(
+        log.debug(
             "Host %s: Checking if file %s exists on remote with command '%s' and result: %s",
             self.host,
             filename,
@@ -690,7 +688,25 @@ class IOSDevice(BaseDevice):
         if re.search(rf"Directory of .*{filename}", result):
             log.debug("Host %s: File %s exists on remote.", self.host, filename)
             return True
-        raise CommandError(cmd, f"Unable to determine if file {filename} exists on remote.")
+        raise CommandError(cmd, f"Unable to determine if file {filename} exists on remote: {result}")
+
+    def verify_file(self, checksum, filename, hashing_algorithm="md5", file_system=None):
+        """Verify a file on the remote device by and validate the checksums.
+
+        Args:
+            checksum (str): The checksum of the file.
+            filename (str): The name of the file to check for on the remote device.
+            hashing_algorithm (str): The hashing algorithm to use (default: "md5").
+            file_system (str): Supported only for IOS and NXOS. The file system for the
+                remote file. If no file_system is provided, then the ``get_file_system``
+                method is used to determine the correct file system to use.
+
+        Returns:
+            (bool): True if the file is verified successfully, False otherwise.
+        """
+        return self.check_file_exists(filename, file_system=file_system) and self.compare_file_checksum(
+            checksum, filename, hashing_algorithm, file_system=file_system
+        )
 
     def file_copy(self, src, dest=None, file_system=None):
         """Copy file to device.
@@ -788,7 +804,7 @@ class IOSDevice(BaseDevice):
 
             # _send_command currently checks for % and raises an error, but during the file copy
             # their may be a % warning that does not indicate a failure so we will use send_command directly.
-            output = self.native.send_command(command, expect_string=expect_regex, read_timeout=900)
+            output = self.native.send_command(command, expect_string=expect_regex, read_timeout=src.timeout)
 
             while current_prompt not in output:
                 # Check for success message in output to break loop and avoid waiting for next prompt
@@ -805,7 +821,7 @@ class IOSDevice(BaseDevice):
                     if re.search(prompt, output, re.IGNORECASE):
                         is_password = "Password" in prompt
                         output = self.native.send_command(
-                            answer, expect_string=expect_regex, read_timeout=900, cmd_verify=not is_password
+                            answer, expect_string=expect_regex, read_timeout=src.timeout, cmd_verify=not is_password
                         )
                         break  # Exit the for loop and check the new output for the next prompt
 

--- a/pyntc/devices/ios_device.py
+++ b/pyntc/devices/ios_device.py
@@ -1,11 +1,9 @@
 """Module for using a Cisco IOS device over SSH."""
 
-from typing import Callable, Optional, Any, Type, Union
-from typing import TYPE_CHECKING
-import contextlib
 import os
 import re
 import time
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from netmiko import ConnectHandler
 from netmiko.cisco import CiscoIosFileTransfer
@@ -59,6 +57,7 @@ class FileTransferURLPull(CiscoIosFileTransfer):
         progress4: Optional[Callable[..., Any]] = None,
         hash_supported: bool = True,
     ) -> None:
+        """Uses Netmiko's FileTransfer class to transfer files to and from the device, but also supports pulling files directly from a URL to the device using the device's own download capabilities."""
         self.ssh_ctl_chan = ssh_conn
         self.source_file = source_file
         self.dest_file = dest_file
@@ -86,9 +85,7 @@ class FileTransferURLPull(CiscoIosFileTransfer):
             self.source_md5 = self.file_md5(source_file) if hash_supported else None
             self.file_size = os.stat(source_file).st_size
         elif direction == "get":
-            self.source_md5 = (
-                self.remote_md5(remote_file=source_file) if hash_supported else None
-            )
+            self.source_md5 = self.remote_md5(remote_file=source_file) if hash_supported else None
             self.file_size = self.remote_file_size(remote_file=source_file)
         elif direction == "url_pull":
             if not isinstance(source_file, FilePullSpec):
@@ -96,10 +93,16 @@ class FileTransferURLPull(CiscoIosFileTransfer):
             # For url_pull, source_file is the URL and dest_file is the filename to save as on the device
             if source_file.hashing_algorithm and source_file.hashing_algorithm.lower() not in {"md5", "sha512"}:
                 raise ValueError("When direction is 'url_pull', hashing_algorithm must be either 'md5' or 'sha512'.")
-            self.source_md5 = source_file.checksum if hash_supported and source_file.hashing_algorithm.lower() == "md5" else None
-            self.source_sha512 = source_file.checksum if hash_supported and source_file.hashing_algorithm.lower() == "sha512" else None
+            self.source_md5 = (
+                source_file.checksum if hash_supported and source_file.hashing_algorithm.lower() == "md5" else None
+            )
+            self.source_sha512 = (
+                source_file.checksum if hash_supported and source_file.hashing_algorithm.lower() == "sha512" else None
+            )
             self.file_size = source_file.file_size
-            self.direction = "put"  # FileTransfer only supports put and get, so treat url_pull as put for the transfer process
+            self.direction = (
+                "put"  # FileTransfer only supports put and get, so treat url_pull as put for the transfer process
+            )
         else:
             raise ValueError("Invalid direction specified")
 
@@ -117,12 +120,18 @@ class FileTransferURLPull(CiscoIosFileTransfer):
             if current_prompt in output:
                 return
             # Assume that the filename and address are sent with the url.
-            if re.search(r"(confirm|Address or name of remote host|Source filename|Destination filename)", output, re.IGNORECASE):
+            if re.search(
+                r"(confirm|Address or name of remote host|Source filename|Destination filename)", output, re.IGNORECASE
+            ):
                 output = self.ssh_ctl_chan.send_command("", expect_string=expect_regex, read_timeout=300)
             if re.search(r"Password", output, re.IGNORECASE):
-                output = self.ssh_ctl_chan.send_command(self.source_file.token, expect_string=expect_regex, read_timeout=300, cmd_verify=False)
+                output = self.ssh_ctl_chan.send_command(
+                    self.source_file.token, expect_string=expect_regex, read_timeout=300, cmd_verify=False
+                )
             if re.search(r"Source username", output, re.IGNORECASE):
-                output = self.ssh_ctl_chan.send_command(self.source_file.username, expect_string=expect_regex, read_timeout=300)
+                output = self.ssh_ctl_chan.send_command(
+                    self.source_file.username, expect_string=expect_regex, read_timeout=300
+                )
             if re.search(r"yes/no|Are you sure you want to continue connecting", output, re.IGNORECASE):
                 output = self.ssh_ctl_chan.send_command("yes", expect_string=expect_regex, read_timeout=300)
 
@@ -133,9 +142,7 @@ class FileTransferURLPull(CiscoIosFileTransfer):
         else:
             super().transfer_file()
 
-    def remote_sha512(
-        self, base_cmd: str = "verify /sha512", remote_file: Optional[str] = None
-    ) -> str:
+    def remote_sha512(self, base_cmd: str = "verify /sha512", remote_file: Optional[str] = None) -> str:
         """Calculate the sha512 hash of the file on the device."""
         if remote_file is None:
             if self.direction == "put":
@@ -144,7 +151,7 @@ class FileTransferURLPull(CiscoIosFileTransfer):
                 remote_file = self.source_file
         remote_sha512_cmd = f"{base_cmd} {self.file_system}/{remote_file}"
         dest_sha512 = self.ssh_ctl_chan._send_command_str(remote_sha512_cmd, read_timeout=300)
-        dest_sha512 = self.process_md5(dest_sha512) # Process MD5 still does what we want for parsing the output.
+        dest_sha512 = self.process_md5(dest_sha512)  # Process MD5 still does what we want for parsing the output.
         return dest_sha512
 
     def compare_md5(self) -> bool:
@@ -154,6 +161,7 @@ class FileTransferURLPull(CiscoIosFileTransfer):
             return self.source_sha512 == dest_sha512
         else:
             return super().compare_md5()
+
 
 @fix_docs
 class IOSDevice(BaseDevice):

--- a/pyntc/utils/models.py
+++ b/pyntc/utils/models.py
@@ -1,17 +1,34 @@
-from dataclasses import dataclass, field, asdict
-from urllib.parse import urlparse
+"""Data Models for Pyntc."""
+
+from dataclasses import asdict, dataclass, field
 from typing import Optional
+from urllib.parse import urlparse
 
 # Use Hashing algorithms from Nautobot's supported list.
 HASHING_ALGORITHMS = {"md5", "sha1", "sha224", "sha384", "sha256", "sha512", "sha3", "blake2", "blake3"}
 
+
 @dataclass
 class FilePullSpec:
+    """Data class to represent the specification for pulling a file from a URL to a network device.
+
+    Args:
+        download_url (str): The URL to download the file from. Can include credentials, but it's recommended to use the username and token fields instead for security reasons.
+        checksum (str): The expected checksum of the file.
+        file_name (str): The name of the file to be saved on the device.
+        hashing_algorithm (str): The hashing algorithm to use for checksum verification. Defaults to "md5".
+        file_size (int, optional): The expected size of the file in bytes. Optional but can be used for an additional layer of verification.
+        username (str, optional): The username for authentication if required by the URL. Optional if credentials are included in the URL.
+        token (str, optional): The password or token for authentication if required by the URL. Optional if credentials are included in the URL.
+        vrf (str, optional): The VRF to use for the download if the device supports VRFs. Optional.
+        ftp_passive (bool): Whether to use passive mode for FTP downloads. Defaults to True.
+    """
+
     download_url: str
     checksum: str
     file_name: str
     hashing_algorithm: str = "md5"
-    file_size: Optional[int] = None # Size in bytes
+    file_size: Optional[int] = None  # Size in bytes
     username: Optional[str] = None
     token: Optional[str] = None  # Password/Token
     vrf: Optional[str] = None
@@ -22,6 +39,7 @@ class FilePullSpec:
     scheme: str = field(init=False)
 
     def __post_init__(self):
+        """Validate the input and prepare the clean URL after initialization."""
         # 1. Validate the hashing algorithm choice
         if self.hashing_algorithm.lower() not in HASHING_ALGORITHMS:
             raise ValueError(f"Unsupported algorithm. Choose from: {HASHING_ALGORITHMS}")

--- a/pyntc/utils/models.py
+++ b/pyntc/utils/models.py
@@ -17,6 +17,7 @@ class FileCopyModel:
         checksum (str): The expected checksum of the file.
         file_name (str): The name of the file to be saved on the device.
         hashing_algorithm (str, optional): The hashing algorithm to use for checksum verification. Defaults to "md5".
+        timeout (int, optional): The timeout for the download operation in seconds. Defaults to 900.
         file_size (int, optional): The expected size of the file in bytes. Optional but can be used for an additional layer of verification.
         username (str, optional): The username for authentication if required by the URL. Optional if credentials are included in the URL.
         token (str, optional): The password or token for authentication if required by the URL. Optional if credentials are included in the URL.
@@ -28,6 +29,7 @@ class FileCopyModel:
     checksum: str
     file_name: str
     hashing_algorithm: str = "md5"
+    timeout: int = 900  # Timeout for the download operation in seconds
     file_size: Optional[int] = None  # Size in bytes
     username: Optional[str] = None
     token: Optional[str] = None  # Password/Token

--- a/pyntc/utils/models.py
+++ b/pyntc/utils/models.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass, field, asdict
+from urllib.parse import urlparse
+from typing import Optional
+
+# Use Hashing algorithms from Nautobot's supported list.
+HASHING_ALGORITHMS = {"md5", "sha1", "sha224", "sha384", "sha256", "sha512", "sha3", "blake2", "blake3"}
+
+@dataclass
+class FilePullSpec:
+    download_url: str
+    checksum: str
+    file_name: str
+    hashing_algorithm: str = "md5"
+    file_size: Optional[int] = None # Size in bytes
+    username: Optional[str] = None
+    token: Optional[str] = None  # Password/Token
+    vrf: Optional[str] = None
+    ftp_passive: bool = True
+
+    # This field is calculated, so we don't pass it in the constructor
+    clean_url: str = field(init=False)
+    scheme: str = field(init=False)
+
+    def __post_init__(self):
+        # 1. Validate the hashing algorithm choice
+        if self.hashing_algorithm.lower() not in HASHING_ALGORITHMS:
+            raise ValueError(f"Unsupported algorithm. Choose from: {HASHING_ALGORITHMS}")
+
+        # Parse the url to extract components
+        parsed = urlparse(self.download_url)
+
+        # Extract username/password from URL if not already provided as arguments
+        if parsed.username and not self.username:
+            self.username = parsed.username
+        if parsed.password and not self.token:
+            self.token = parsed.password
+
+        # 3. Create the 'clean_url' (URL without the credentials)
+        # This is what you actually send to the device if using ip http client
+        port = f":{parsed.port}" if parsed.port else ""
+        self.clean_url = f"{parsed.scheme}://{parsed.hostname}{port}{parsed.path}"
+        self.scheme = parsed.scheme
+
+        # Handle query params if they exist (though we're avoiding '?' for Cisco)
+        if parsed.query:
+            self.clean_url += f"?{parsed.query}"
+
+    @classmethod
+    def from_dict(cls, data: dict):
+        """Allows users to just pass a dictionary if they prefer."""
+        return cls(**data)
+
+    def to_dict(self):
+        """Useful for logging or passing to other Nornir tasks."""
+        return asdict(self)

--- a/pyntc/utils/models.py
+++ b/pyntc/utils/models.py
@@ -9,19 +9,19 @@ HASHING_ALGORITHMS = {"md5", "sha1", "sha224", "sha384", "sha256", "sha512", "sh
 
 
 @dataclass
-class FilePullSpec:
+class FileCopyModel:
     """Data class to represent the specification for pulling a file from a URL to a network device.
 
     Args:
         download_url (str): The URL to download the file from. Can include credentials, but it's recommended to use the username and token fields instead for security reasons.
         checksum (str): The expected checksum of the file.
         file_name (str): The name of the file to be saved on the device.
-        hashing_algorithm (str): The hashing algorithm to use for checksum verification. Defaults to "md5".
+        hashing_algorithm (str, optional): The hashing algorithm to use for checksum verification. Defaults to "md5".
         file_size (int, optional): The expected size of the file in bytes. Optional but can be used for an additional layer of verification.
         username (str, optional): The username for authentication if required by the URL. Optional if credentials are included in the URL.
         token (str, optional): The password or token for authentication if required by the URL. Optional if credentials are included in the URL.
         vrf (str, optional): The VRF to use for the download if the device supports VRFs. Optional.
-        ftp_passive (bool): Whether to use passive mode for FTP downloads. Defaults to True.
+        ftp_passive (bool, optional): Whether to use passive mode for FTP downloads. Defaults to True.
     """
 
     download_url: str

--- a/tasks.py
+++ b/tasks.py
@@ -189,7 +189,7 @@ def pylint(context):
     Args:
         context (obj): Used to run specific commands
     """
-    exec_cmd = 'pylint pyntc'
+    exec_cmd = "pylint --verbose pyntc"
     run_command(context, exec_cmd)
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -189,7 +189,7 @@ def pylint(context):
     Args:
         context (obj): Used to run specific commands
     """
-    exec_cmd = 'find . -name "*.py" | grep -vE "tests/unit" | xargs pylint'
+    exec_cmd = 'pylint pyntc'
     run_command(context, exec_cmd)
 
 

--- a/tests/unit/test_devices/test_ios_device.py
+++ b/tests/unit/test_devices/test_ios_device.py
@@ -6,9 +6,9 @@ import mock
 import pytest
 
 from pyntc.devices import IOSDevice
-from pyntc.devices.ios_device import FileTransferURLPull, CiscoIosFileTransfer
 from pyntc.devices import ios_device as ios_module
 from pyntc.devices.base_device import RollbackError
+from pyntc.devices.ios_device import CiscoIosFileTransfer, FileTransferURLPull
 from pyntc.utils.models import FilePullSpec
 
 from .device_mocks.ios import send_command, send_command_expect
@@ -149,7 +149,9 @@ class TestIOSDevice(unittest.TestCase):
         mock_ft_instance.check_file_exists.side_effect = [False, True]
         self.device.file_copy("path/to/source_file")
 
-        mock_ft.assert_called_with(self.device.native, "path/to/source_file", "source_file", direction="put", file_system="flash:")
+        mock_ft.assert_called_with(
+            self.device.native, "path/to/source_file", "source_file", direction="put", file_system="flash:"
+        )
         mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()
@@ -165,7 +167,9 @@ class TestIOSDevice(unittest.TestCase):
         mock_ft_instance.check_file_exists.side_effect = [False, True]
         self.device.file_copy("source_file", "dest_file")
 
-        mock_ft.assert_called_with(self.device.native, "source_file", "dest_file", direction="put", file_system="flash:")
+        mock_ft.assert_called_with(
+            self.device.native, "source_file", "dest_file", direction="put", file_system="flash:"
+        )
         mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()
@@ -197,7 +201,9 @@ class TestIOSDevice(unittest.TestCase):
 
         self.device.file_copy("path/to/source_file")
 
-        mock_ft.assert_called_with(self.device.native, "path/to/source_file", "source_file", direction="put", file_system="flash:")
+        mock_ft.assert_called_with(
+            self.device.native, "path/to/source_file", "source_file", direction="put", file_system="flash:"
+        )
         mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()
@@ -417,7 +423,6 @@ class TestIOSDevice(unittest.TestCase):
 
 
 class TestFileTransferURLPull(unittest.TestCase):
-
     @mock.patch.object(IOSDevice, "open")
     @mock.patch.object(IOSDevice, "close")
     @mock.patch("netmiko.cisco.cisco_ios.CiscoIosSSH", autospec=True)
@@ -445,8 +450,12 @@ class TestFileTransferURLPull(unittest.TestCase):
         self.device.native.reset_mock()
 
     def test_init(self):
-        ft = FileTransferURLPull(self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:")
-        self.assertEqual(ft.direction, "put") # The class should set direction to "put" if using url_pull as Netmiko only supports "put" or "get"
+        ft = FileTransferURLPull(
+            self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:"
+        )
+        self.assertEqual(
+            ft.direction, "put"
+        )  # The class should set direction to "put" if using url_pull as Netmiko only supports "put" or "get"
         self.assertEqual(ft.source_file, self.source_file)
         self.assertEqual(ft.dest_file, self.dest_file)
         self.assertEqual(ft.source_md5, self.source_file.checksum)
@@ -455,8 +464,12 @@ class TestFileTransferURLPull(unittest.TestCase):
 
     def test_init_sha512(self):
         self.source_file.hashing_algorithm = "sha512"
-        ft = FileTransferURLPull(self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:")
-        self.assertEqual(ft.direction, "put") # The class should set direction to "put" if using url_pull as Netmiko only supports "put" or "get"
+        ft = FileTransferURLPull(
+            self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:"
+        )
+        self.assertEqual(
+            ft.direction, "put"
+        )  # The class should set direction to "put" if using url_pull as Netmiko only supports "put" or "get"
         self.assertEqual(ft.source_file, self.source_file)
         self.assertIsNone(ft.source_md5)
         self.assertEqual(ft.source_sha512, self.source_file.checksum)
@@ -467,7 +480,9 @@ class TestFileTransferURLPull(unittest.TestCase):
     @mock.patch.object(FileTransferURLPull, "file_md5", return_value="abc123")
     @mock.patch.object(FileTransferURLPull, "pull_file")
     def test_transfer_file_pull_file(self, mock_pull_file, mock_file_md5, mock_os, mock_transfer_file):
-        ft = FileTransferURLPull(self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:")
+        ft = FileTransferURLPull(
+            self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:"
+        )
         ft.transfer_file()
         mock_pull_file.assert_called_once()
         mock_transfer_file.assert_not_called()
@@ -477,7 +492,9 @@ class TestFileTransferURLPull(unittest.TestCase):
     @mock.patch.object(FileTransferURLPull, "file_md5", return_value="abc123")
     @mock.patch.object(FileTransferURLPull, "pull_file")
     def test_transfer_file_transfer_file(self, mock_pull_file, mock_file_md5, mock_os, mock_transfer_file):
-        ft2 = FileTransferURLPull(self.device.native, "test1.txt", self.dest_file, direction="put", file_system="flash:")
+        ft2 = FileTransferURLPull(
+            self.device.native, "test1.txt", self.dest_file, direction="put", file_system="flash:"
+        )
         ft2.transfer_file()
         mock_pull_file.assert_not_called()
         mock_transfer_file.assert_called_once()
@@ -489,7 +506,9 @@ class TestFileTransferURLPull(unittest.TestCase):
     @mock.patch.object(FileTransferURLPull, "pull_file")
     def test_compare_md5_sha512(self, mock_pull_file, mock_file_md5, mock_os, mock_remote_sha512, mock_compare_md5):
         self.source_file.hashing_algorithm = "sha512"
-        ft = FileTransferURLPull(self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:")
+        ft = FileTransferURLPull(
+            self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:"
+        )
         ft.compare_md5()
         mock_compare_md5.assert_not_called()
         mock_remote_sha512.assert_called_once()
@@ -500,26 +519,35 @@ class TestFileTransferURLPull(unittest.TestCase):
     @mock.patch.object(FileTransferURLPull, "file_md5", return_value="abc123")
     @mock.patch.object(FileTransferURLPull, "pull_file")
     def test_compare_md5(self, mock_pull_file, mock_file_md5, mock_os, mock_remote_sha512, mock_compare_md5):
-        ft = FileTransferURLPull(self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:")
+        ft = FileTransferURLPull(
+            self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:"
+        )
         ft.compare_md5()
         mock_compare_md5.assert_called_once()
         mock_remote_sha512.assert_not_called()
 
     def test_remote_sha512(self):
-        ft = FileTransferURLPull(self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:")
+        ft = FileTransferURLPull(
+            self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:"
+        )
         with mock.patch.object(self.device.native, "_send_command_str", return_value="= abc123") as mock_send_command:
             result = ft.remote_sha512()
             mock_send_command.assert_called_once_with("verify /sha512 flash:/file.bin", read_timeout=300)
             self.assertEqual(result, "abc123")
 
-
     def test_pull_file(self):
         self.device.native.find_prompt.return_value = "router#"
-        ft = FileTransferURLPull(self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:")
-        with mock.patch.object(self.device.native, "send_command", return_value="copy http://example.com/file.bin flash:/file.bin\nCopy complete\nrouter#") as mock_send_command:
+        ft = FileTransferURLPull(
+            self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:"
+        )
+        with mock.patch.object(
+            self.device.native,
+            "send_command",
+            return_value="copy http://example.com/file.bin flash:/file.bin\nCopy complete\nrouter#",
+        ) as mock_send_command:
             ft.pull_file()
             mock_send_command.assert_called_once_with(
-                "copy http://example.com/file.bin flash:file.bin", # HTTP does not use VRF in the command
+                "copy http://example.com/file.bin flash:file.bin",  # HTTP does not use VRF in the command
                 expect_string="(Destination filename|router\\#|confirm|Password|Address or name of remote host|Source username|Source filename|yes/no|Are you sure you want to continue connecting)",
                 read_timeout=300,
             )
@@ -534,8 +562,18 @@ class TestFileTransferURLPull(unittest.TestCase):
             vrf="VRF1",
             ftp_passive=True,
         )
-        ft2 = FileTransferURLPull(self.device.native, source_file=source_file, dest_file=self.dest_file, direction="url_pull", file_system="flash:")
-        with mock.patch.object(self.device.native, "send_command", return_value="copy sftp://example.com/file.bin flash:file.bin vrf VRF1\nCopy complete\nrouter#") as mock_send_command:
+        ft2 = FileTransferURLPull(
+            self.device.native,
+            source_file=source_file,
+            dest_file=self.dest_file,
+            direction="url_pull",
+            file_system="flash:",
+        )
+        with mock.patch.object(
+            self.device.native,
+            "send_command",
+            return_value="copy sftp://example.com/file.bin flash:file.bin vrf VRF1\nCopy complete\nrouter#",
+        ) as mock_send_command:
             ft2.pull_file()
             mock_send_command.assert_called_once_with(
                 "copy sftp://example.com/file.bin flash:file.bin vrf VRF1",
@@ -561,7 +599,7 @@ class TestFileTransferURLPull(unittest.TestCase):
             source_file=source_file,
             dest_file=self.dest_file,
             direction="url_pull",
-            file_system="flash:"
+            file_system="flash:",
         )
         responses = [
             "Address or name of remote host [example.com]?",
@@ -570,7 +608,7 @@ class TestFileTransferURLPull(unittest.TestCase):
             "Destination filename [file.bin]?",
             "%Warning: There is a file already existing with this name\nDo you want to over write? [confirm]",
             "Password: ",
-            "1024 bytes copied in 2 secs\nrouter#"
+            "1024 bytes copied in 2 secs\nrouter#",
         ]
 
         # Shared expect_string to keep the assertion clean
@@ -585,44 +623,24 @@ class TestFileTransferURLPull(unittest.TestCase):
                 mock.call(
                     "copy sftp://example.com/file.bin flash:file.bin vrf VRF1",
                     expect_string=expect_regex,
-                    read_timeout=300
+                    read_timeout=300,
                 ),
                 # The response to the "Address or name of remote host" prompt (sending a newline/empty string to accept the default)
-                mock.call(
-                    "",
-                    expect_string=expect_regex,
-                    read_timeout=300
-                ),
+                mock.call("", expect_string=expect_regex, read_timeout=300),
                 # The response to the "Source username" prompt (sending the username)
-                mock.call(
-                    "user",
-                    expect_string=expect_regex,
-                    read_timeout=300
-                ),
+                mock.call("user", expect_string=expect_regex, read_timeout=300),
                 # The response to the "Source filename" prompt (sending a newline/empty string to accept the default)
-                mock.call(
-                    "",
-                    expect_string=expect_regex,
-                    read_timeout=300
-                ),
+                mock.call("", expect_string=expect_regex, read_timeout=300),
                 # The response to the "Destination filename" prompt (sending a newline/empty string to accept the default)
-                mock.call(
-                    "",
-                    expect_string=expect_regex,
-                    read_timeout=300
-                ),
+                mock.call("", expect_string=expect_regex, read_timeout=300),
                 # The response to the confirm overwrite prompt (sending a newline/empty string to accept)
-                mock.call(
-                    "",
-                    expect_string=expect_regex,
-                    read_timeout=300
-                ),
+                mock.call("", expect_string=expect_regex, read_timeout=300),
                 # The response to the Password prompt
                 mock.call(
                     "pass",
                     expect_string=expect_regex,
                     read_timeout=300,
-                    cmd_verify=False  # Don't verify the command for password input
+                    cmd_verify=False,  # Don't verify the command for password input
                 ),
             ]
 

--- a/tests/unit/test_devices/test_ios_device.py
+++ b/tests/unit/test_devices/test_ios_device.py
@@ -487,6 +487,7 @@ class TestIOSDevice(unittest.TestCase):
             checksum="12345",
             file_name="test.bin",
             hashing_algorithm="md5",
+            timeout=900,
         )
         self.assertEqual(src.clean_url, "sftp://1.1.1.1/test.bin")
         self.assertEqual(src.username, "user")
@@ -536,6 +537,7 @@ class TestIOSDevice(unittest.TestCase):
             checksum="12345",
             file_name="test.bin",
             hashing_algorithm="md5",
+            timeout=300,
         )
         self.assertEqual(src.clean_url, src.download_url)
         self.assertIsNone(src.username)
@@ -557,14 +559,11 @@ class TestIOSDevice(unittest.TestCase):
             self.device.remote_file_copy(src, file_system="flash:")
 
             # Verify the command sent was correct
-            self.device.native.send_command.assert_any_call(
-                "copy sftp://1.1.1.1/test.bin flash:test.bin", expect_string=mock.ANY, read_timeout=900
-            )
             self.device.native.send_command.assert_has_calls(
                 [
-                    mock.call("copy sftp://1.1.1.1/test.bin flash:test.bin", expect_string=mock.ANY, read_timeout=900),
+                    mock.call("copy sftp://1.1.1.1/test.bin flash:test.bin", expect_string=mock.ANY, read_timeout=300),
                     mock.call(
-                        "", expect_string=mock.ANY, read_timeout=900, cmd_verify=True
+                        "", expect_string=mock.ANY, read_timeout=300, cmd_verify=True
                     ),  # Respond to "Address or name of remote host"
                 ]
             )

--- a/tests/unit/test_devices/test_ios_device.py
+++ b/tests/unit/test_devices/test_ios_device.py
@@ -8,8 +8,7 @@ import pytest
 from pyntc.devices import IOSDevice
 from pyntc.devices import ios_device as ios_module
 from pyntc.devices.base_device import RollbackError
-from pyntc.devices.ios_device import CiscoIosFileTransfer, FileTransferURLPull
-from pyntc.utils.models import FilePullSpec
+from pyntc.utils.models import FileCopyModel
 
 from .device_mocks.ios import send_command, send_command_expect
 
@@ -103,7 +102,7 @@ class TestIOSDevice(unittest.TestCase):
         self.assertTrue(result)
         self.device.native.send_command_timing.assert_any_call("copy running-config startup-config")
 
-    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
+    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
     def test_file_copy_remote_exists(self, mock_ft):
         self.device.native.send_command.side_effect = None
         self.device.native.send_command.return_value = "flash: /dev/null"
@@ -115,7 +114,7 @@ class TestIOSDevice(unittest.TestCase):
 
         self.assertTrue(result)
 
-    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
+    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
     def test_file_copy_remote_exists_bad_md5(self, mock_ft):
         self.device.native.send_command_timing.side_effect = None
         self.device.native.send_command.return_value = "flash: /dev/null"
@@ -127,7 +126,7 @@ class TestIOSDevice(unittest.TestCase):
 
         self.assertFalse(result)
 
-    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
+    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
     def test_file_copy_remote_exists_not(self, mock_ft):
         self.device.native.send_command_timing.side_effect = None
         self.device.native.send_command.return_value = "flash: /dev/null"
@@ -139,85 +138,92 @@ class TestIOSDevice(unittest.TestCase):
 
         self.assertFalse(result)
 
-    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
+    @mock.patch.object(IOSDevice, "get_local_checksum")
+    @mock.patch.object(IOSDevice, "verify_file")
+    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
     @mock.patch.object(IOSDevice, "open")
-    def test_file_copy(self, mock_open, mock_ft):
+    def test_file_copy(self, mock_open, mock_ft, mock_verify_file, mock_get_local_checksum):
         self.device.native.send_command.side_effect = None
         self.device.native.send_command.return_value = "flash: /dev/null"
 
         mock_ft_instance = mock_ft.return_value
-        mock_ft_instance.check_file_exists.side_effect = [False, True]
+        mock_verify_file.side_effect = [False, True]
+        mock_get_local_checksum.return_value = "dummy_checksum"
         self.device.file_copy("path/to/source_file")
 
-        mock_ft.assert_called_with(
-            self.device.native, "path/to/source_file", "source_file", direction="put", file_system="flash:"
-        )
+        mock_ft.assert_called_with(self.device.native, "path/to/source_file", "source_file", file_system="flash:")
         mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()
         mock_open.assert_called_once()
 
-    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
+    @mock.patch.object(IOSDevice, "get_local_checksum")
+    @mock.patch.object(IOSDevice, "verify_file")
+    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
     @mock.patch.object(IOSDevice, "open")
-    def test_file_copy_different_dest(self, mock_open, mock_ft):
+    def test_file_copy_different_dest(self, mock_open, mock_ft, mock_verify_file, mock_get_local_checksum):
         self.device.native.send_command_timing.side_effect = None
         self.device.native.send_command.return_value = "flash: /dev/null"
         mock_ft_instance = mock_ft.return_value
 
-        mock_ft_instance.check_file_exists.side_effect = [False, True]
+        mock_verify_file.side_effect = [False, True]
         self.device.file_copy("source_file", "dest_file")
 
-        mock_ft.assert_called_with(
-            self.device.native, "source_file", "dest_file", direction="put", file_system="flash:"
-        )
+        mock_ft.assert_called_with(self.device.native, "source_file", "dest_file", file_system="flash:")
         mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()
         mock_open.assert_called_once()
 
-    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
+    @mock.patch.object(IOSDevice, "get_local_checksum")
+    @mock.patch.object(IOSDevice, "verify_file")
+    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
     @mock.patch.object(IOSDevice, "open")
-    def test_file_copy_fail(self, mock_open, mock_ft):
+    def test_file_copy_fail(self, mock_open, mock_ft, mock_verify_file, mock_get_local_checksum):
         self.device.native.send_command_timing.side_effect = None
         self.device.native.send_command.return_value = "flash: /dev/null"
         mock_ft_instance = mock_ft.return_value
         mock_ft_instance.transfer_file.side_effect = Exception
-        mock_ft_instance.check_file_exists.return_value = False
+        mock_verify_file.return_value = False
 
         with self.assertRaises(ios_module.FileTransferError):
             self.device.file_copy("source_file")
 
         mock_open.assert_not_called()
 
-    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
+    @mock.patch.object(IOSDevice, "get_local_checksum")
+    @mock.patch.object(IOSDevice, "verify_file")
+    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
     @mock.patch.object(IOSDevice, "open")
-    def test_file_copy_socket_closed_good_md5(self, mock_open, mock_ft):
+    def test_file_copy_socket_closed_good_md5(self, mock_open, mock_ft, mock_verify_file, mock_get_local_checksum):
         self.device.native.send_command_timing.side_effect = None
         self.device.native.send_command.return_value = "flash: /dev/null"
         mock_ft_instance = mock_ft.return_value
         mock_ft_instance.transfer_file.side_effect = OSError
-        mock_ft_instance.check_file_exists.side_effect = [False, True]
-        mock_ft_instance.compare_md5.side_effect = [True, True]
+        mock_verify_file.side_effect = [False, True]
+        mock_ft_instance.compare_md5.return_value = True
 
         self.device.file_copy("path/to/source_file")
 
-        mock_ft.assert_called_with(
-            self.device.native, "path/to/source_file", "source_file", direction="put", file_system="flash:"
-        )
+        mock_ft.assert_called_with(self.device.native, "path/to/source_file", "source_file", file_system="flash:")
         mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()
-        mock_ft_instance.compare_md5.assert_has_calls([mock.call(), mock.call()])
+        mock_ft_instance.compare_md5.assert_has_calls([mock.call()])
         mock_open.assert_called_once()
 
-    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
+    @mock.patch.object(IOSDevice, "get_local_checksum")
+    @mock.patch.object(IOSDevice, "verify_file")
+    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
     @mock.patch.object(IOSDevice, "open")
-    def test_file_copy_fail_socket_closed_bad_md5(self, mock_open, mock_ft):
+    def test_file_copy_fail_socket_closed_bad_md5(self, mock_open, mock_ft, mock_verify_file, mock_get_local_checksum):
         self.device.native.send_command_timing.side_effect = None
         self.device.native.send_command.return_value = "flash: /dev/null"
         mock_ft_instance = mock_ft.return_value
         mock_ft_instance.transfer_file.side_effect = OSError
         mock_ft_instance.check_file_exists.return_value = False
+        mock_verify_file.return_value = False
+        mock_get_local_checksum.return_value = "dummy_checksum"
         mock_ft_instance.compare_md5.return_value = False
 
         with self.assertRaises(ios_module.SocketClosedError):
@@ -421,234 +427,173 @@ class TestIOSDevice(unittest.TestCase):
         mock_wait.assert_not_called()
         mock_reboot.assert_not_called()
 
+    def test_get_local_checksum(self):
+        # Create a temporary file with known content
+        test_file_path = "test_file.txt"
+        test_content = "This is a test file for checksum."
+        with open(test_file_path, "w") as f:
+            f.write(test_content)
 
-class TestFileTransferURLPull(unittest.TestCase):
-    @mock.patch.object(IOSDevice, "open")
-    @mock.patch.object(IOSDevice, "close")
-    @mock.patch("netmiko.cisco.cisco_ios.CiscoIosSSH", autospec=True)
-    def setUp(self, mock_miko, mock_close, mock_open):
-        self.device = IOSDevice("host", "user", "pass")
-        mock_miko.send_command_timing.side_effect = send_command
-        mock_miko.send_command_expect.side_effect = send_command_expect
-        mock_miko.device_type = "cisco_ios"
-        self.device.native = mock_miko  # Mock the native connection for testing
-        self.source_file = FilePullSpec(
-            download_url="http://example.com/file.bin",
-            checksum="abc123",
-            file_name="file.bin",
+        import hashlib
+
+        with self.subTest("Test get_local_checksum returns correct md5 checksum"):
+            expected_checksum = hashlib.md5(test_content.encode()).hexdigest()
+            actual_checksum = self.device.get_local_checksum(test_file_path)
+            self.assertEqual(actual_checksum, expected_checksum)
+
+        with self.subTest("Test get_local_checksum returns correct sha512 checksum"):
+            expected_checksum = hashlib.sha512(test_content.encode()).hexdigest()
+            actual_checksum = self.device.get_local_checksum(test_file_path, hashing_algorithm="sha512")
+            self.assertEqual(actual_checksum, expected_checksum)
+
+        with self.subTest("Test get_local_checksum with add_newline=True"):
+            expected_checksum = hashlib.md5((test_content + "\n").encode()).hexdigest()
+            actual_checksum = self.device.get_local_checksum(test_file_path, add_newline=True)
+            self.assertEqual(actual_checksum, expected_checksum)
+
+        with self.subTest("Test get_local_checksum with invalid hashing algorithm"):
+            with self.assertRaises(ValueError):
+                self.device.get_local_checksum(test_file_path, hashing_algorithm="invalid_algo")
+
+        # Clean up the temporary file
+        os.remove(test_file_path)
+
+    def test_check_file_exists(self):
+        with self.subTest("Test check_file_exists returns True when file exists"):
+            self.device.native.send_command_expect.side_effect = None
+            self.device.native.send_command.return_value = "Directory of flash:/file.txt\n"
+            self.assertTrue(self.device.check_file_exists("file.txt", file_system="flash:"))
+
+        with self.subTest("Test check_file_exists returns False when file does not exist"):
+            self.device.native.send_command_expect.side_effect = None
+            self.device.native.send_command.return_value = "%Error opening flash:/file.txt\n"
+            self.assertFalse(self.device.check_file_exists("file.txt", file_system="flash:"))
+
+    def test_get_remote_checksum(self):
+        with self.subTest("Test get_remote_checksum returns correct md5 checksum"):
+            self.device.native.send_command_timing.side_effect = None
+            self.device.native.send_command_timing.return_value = "MD5 (flash:/file.txt) = dummy_checksum"
+            self.assertEqual(self.device.get_remote_checksum("file.txt", file_system="flash:"), "dummy_checksum")
+
+        with self.subTest("Test get_remote_checksum with invalid hashing algorithm"):
+            with self.assertRaises(ValueError):
+                self.device.get_remote_checksum("file.txt", hashing_algorithm="invalid_algo", file_system="flash:")
+
+    @mock.patch.object(IOSDevice, "verify_file")
+    def test_remote_file_copy_success(self, mock_verify):
+        # Setup file model
+        src = FileCopyModel(
+            download_url="sftp://user:test@1.1.1.1/test.bin",
+            checksum="12345",
+            file_name="test.bin",
             hashing_algorithm="md5",
-            file_size=1024,
-            username="user",
-            token="pass",
-            vrf="VRF1",
-            ftp_passive=True,
         )
-        self.dest_file = "file.bin"
+        self.assertEqual(src.clean_url, "sftp://1.1.1.1/test.bin")
+        self.assertEqual(src.username, "user")
+        self.assertEqual(src.token, "test")
 
-    def tearDown(self):
-        # Reset the mock so we don't have transient test effects
-        self.device.native.reset_mock()
+        # Scenario: First verify_file fails (needs copy), second verify_file succeeds (copy worked)
+        mock_verify.side_effect = [False, True]
 
-    def test_init(self):
-        ft = FileTransferURLPull(
-            self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:"
-        )
-        self.assertEqual(
-            ft.direction, "put"
-        )  # The class should set direction to "put" if using url_pull as Netmiko only supports "put" or "get"
-        self.assertEqual(ft.source_file, self.source_file)
-        self.assertEqual(ft.dest_file, self.dest_file)
-        self.assertEqual(ft.source_md5, self.source_file.checksum)
-        self.assertIsNone(ft.source_sha512)
-        self.assertTrue(ft.pull_from_url)
-
-    def test_init_sha512(self):
-        self.source_file.hashing_algorithm = "sha512"
-        ft = FileTransferURLPull(
-            self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:"
-        )
-        self.assertEqual(
-            ft.direction, "put"
-        )  # The class should set direction to "put" if using url_pull as Netmiko only supports "put" or "get"
-        self.assertEqual(ft.source_file, self.source_file)
-        self.assertIsNone(ft.source_md5)
-        self.assertEqual(ft.source_sha512, self.source_file.checksum)
-        self.assertTrue(ft.pull_from_url)
-
-    @mock.patch.object(CiscoIosFileTransfer, "transfer_file")
-    @mock.patch("pyntc.devices.ios_device.os", return_value=1024)
-    @mock.patch.object(FileTransferURLPull, "file_md5", return_value="abc123")
-    @mock.patch.object(FileTransferURLPull, "pull_file")
-    def test_transfer_file_pull_file(self, mock_pull_file, mock_file_md5, mock_os, mock_transfer_file):
-        ft = FileTransferURLPull(
-            self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:"
-        )
-        ft.transfer_file()
-        mock_pull_file.assert_called_once()
-        mock_transfer_file.assert_not_called()
-
-    @mock.patch.object(CiscoIosFileTransfer, "transfer_file")
-    @mock.patch("pyntc.devices.ios_device.os", return_value=1024)
-    @mock.patch.object(FileTransferURLPull, "file_md5", return_value="abc123")
-    @mock.patch.object(FileTransferURLPull, "pull_file")
-    def test_transfer_file_transfer_file(self, mock_pull_file, mock_file_md5, mock_os, mock_transfer_file):
-        ft2 = FileTransferURLPull(
-            self.device.native, "test1.txt", self.dest_file, direction="put", file_system="flash:"
-        )
-        ft2.transfer_file()
-        mock_pull_file.assert_not_called()
-        mock_transfer_file.assert_called_once()
-
-    @mock.patch.object(CiscoIosFileTransfer, "compare_md5")
-    @mock.patch.object(FileTransferURLPull, "remote_sha512", return_value="abc123")
-    @mock.patch("pyntc.devices.ios_device.os", return_value=1024)
-    @mock.patch.object(FileTransferURLPull, "file_md5", return_value="abc123")
-    @mock.patch.object(FileTransferURLPull, "pull_file")
-    def test_compare_md5_sha512(self, mock_pull_file, mock_file_md5, mock_os, mock_remote_sha512, mock_compare_md5):
-        self.source_file.hashing_algorithm = "sha512"
-        ft = FileTransferURLPull(
-            self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:"
-        )
-        ft.compare_md5()
-        mock_compare_md5.assert_not_called()
-        mock_remote_sha512.assert_called_once()
-
-    @mock.patch.object(CiscoIosFileTransfer, "compare_md5")
-    @mock.patch.object(FileTransferURLPull, "remote_sha512", return_value="abc123")
-    @mock.patch("pyntc.devices.ios_device.os", return_value=1024)
-    @mock.patch.object(FileTransferURLPull, "file_md5", return_value="abc123")
-    @mock.patch.object(FileTransferURLPull, "pull_file")
-    def test_compare_md5(self, mock_pull_file, mock_file_md5, mock_os, mock_remote_sha512, mock_compare_md5):
-        ft = FileTransferURLPull(
-            self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:"
-        )
-        ft.compare_md5()
-        mock_compare_md5.assert_called_once()
-        mock_remote_sha512.assert_not_called()
-
-    def test_remote_sha512(self):
-        ft = FileTransferURLPull(
-            self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:"
-        )
-        with mock.patch.object(self.device.native, "_send_command_str", return_value="= abc123") as mock_send_command:
-            result = ft.remote_sha512()
-            mock_send_command.assert_called_once_with("verify /sha512 flash:/file.bin", read_timeout=300)
-            self.assertEqual(result, "abc123")
-
-    def test_pull_file(self):
-        self.device.native.find_prompt.return_value = "router#"
-        ft = FileTransferURLPull(
-            self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:"
-        )
-        with mock.patch.object(
-            self.device.native,
-            "send_command",
-            return_value="copy http://example.com/file.bin flash:/file.bin\nCopy complete\nrouter#",
-        ) as mock_send_command:
-            ft.pull_file()
-            mock_send_command.assert_called_once_with(
-                "copy http://example.com/file.bin flash:file.bin",  # HTTP does not use VRF in the command
-                expect_string="(Destination filename|router\\#|confirm|Password|Address or name of remote host|Source username|Source filename|yes/no|Are you sure you want to continue connecting)",
-                read_timeout=300,
-            )
-        source_file = FilePullSpec(
-            download_url="sftp://example.com/file.bin",
-            checksum="abc123",
-            file_name="file.bin",
-            hashing_algorithm="md5",
-            file_size=1024,
-            username="user",
-            token="pass",
-            vrf="VRF1",
-            ftp_passive=True,
-        )
-        ft2 = FileTransferURLPull(
-            self.device.native,
-            source_file=source_file,
-            dest_file=self.dest_file,
-            direction="url_pull",
-            file_system="flash:",
-        )
-        with mock.patch.object(
-            self.device.native,
-            "send_command",
-            return_value="copy sftp://example.com/file.bin flash:file.bin vrf VRF1\nCopy complete\nrouter#",
-        ) as mock_send_command:
-            ft2.pull_file()
-            mock_send_command.assert_called_once_with(
-                "copy sftp://example.com/file.bin flash:file.bin vrf VRF1",
-                expect_string="(Destination filename|router\\#|confirm|Password|Address or name of remote host|Source username|Source filename|yes/no|Are you sure you want to continue connecting)",
-                read_timeout=300,
-            )
-
-    def test_pull_file_all_prompts(self):
-        self.device.native.find_prompt.return_value = "router#"
-        source_file = FilePullSpec(
-            download_url="sftp://example.com/file.bin",
-            checksum="abc123",
-            file_name="file.bin",
-            hashing_algorithm="md5",
-            file_size=1024,
-            username="user",
-            token="pass",
-            vrf="VRF1",
-            ftp_passive=True,
-        )
-        ft = FileTransferURLPull(
-            self.device.native,
-            source_file=source_file,
-            dest_file=self.dest_file,
-            direction="url_pull",
-            file_system="flash:",
-        )
-        responses = [
-            "Address or name of remote host [example.com]?",
-            "Source username [user]?",
-            "Source filename [file.bin]?",
-            "Destination filename [file.bin]?",
-            "%Warning: There is a file already existing with this name\nDo you want to over write? [confirm]",
-            "Password: ",
-            "1024 bytes copied in 2 secs\nrouter#",
+        # Simulate the prompt sequence:
+        # 1. Initial command -> gets "Address or name of remote host"
+        # 2. Responds with "" -> gets "Copy complete"
+        self.device.native.send_command.side_effect = [
+            "Address or name of remote host [1.1.1.1]?",
+            "Source username?",
+            "Password:",
+            "123456 bytes copied in 10.2 secs. Copy complete.",
         ]
+        self.device.native.find_prompt.return_value = "Router#"
 
-        # Shared expect_string to keep the assertion clean
-        expect_regex = r"(Destination filename|router\#|confirm|Password|Address or name of remote host|Source username|Source filename|yes/no|Are you sure you want to continue connecting)"
+        with self.subTest("Test successful copy with interactive prompts"):
+            self.device.remote_file_copy(src, dest="test.bin", file_system="flash:")
 
-        with mock.patch.object(self.device.native, "send_command", side_effect=responses) as mock_send_command:
-            ft.pull_file()
+            # Verify the command sent was correct
+            self.device.native.send_command.assert_any_call(
+                "copy sftp://1.1.1.1/test.bin flash:test.bin", expect_string=mock.ANY, read_timeout=900
+            )
+            self.device.native.send_command.assert_has_calls(
+                [
+                    mock.call("copy sftp://1.1.1.1/test.bin flash:test.bin", expect_string=mock.ANY, read_timeout=900),
+                    mock.call(
+                        "", expect_string=mock.ANY, read_timeout=900, cmd_verify=True
+                    ),  # Respond to "Address or name of remote host"
+                    mock.call(
+                        "user", expect_string=mock.ANY, read_timeout=900, cmd_verify=True
+                    ),  # Respond to "Source username?"
+                    mock.call(
+                        "test", expect_string=mock.ANY, read_timeout=900, cmd_verify=False
+                    ),  # Respond to "Password:"
+                ]
+            )
 
-            # Define the expected sequence of calls
-            expected_calls = [
-                # The initial copy command
-                mock.call(
-                    "copy sftp://example.com/file.bin flash:file.bin vrf VRF1",
-                    expect_string=expect_regex,
-                    read_timeout=300,
-                ),
-                # The response to the "Address or name of remote host" prompt (sending a newline/empty string to accept the default)
-                mock.call("", expect_string=expect_regex, read_timeout=300),
-                # The response to the "Source username" prompt (sending the username)
-                mock.call("user", expect_string=expect_regex, read_timeout=300),
-                # The response to the "Source filename" prompt (sending a newline/empty string to accept the default)
-                mock.call("", expect_string=expect_regex, read_timeout=300),
-                # The response to the "Destination filename" prompt (sending a newline/empty string to accept the default)
-                mock.call("", expect_string=expect_regex, read_timeout=300),
-                # The response to the confirm overwrite prompt (sending a newline/empty string to accept)
-                mock.call("", expect_string=expect_regex, read_timeout=300),
-                # The response to the Password prompt
-                mock.call(
-                    "pass",
-                    expect_string=expect_regex,
-                    read_timeout=300,
-                    cmd_verify=False,  # Don't verify the command for password input
-                ),
-            ]
+    @mock.patch.object(IOSDevice, "verify_file")
+    def test_remote_file_copy_no_dest(self, mock_verify):
+        # Setup file model
+        src = FileCopyModel(
+            download_url="sftp://1.1.1.1/test.bin",
+            checksum="12345",
+            file_name="test.bin",
+            hashing_algorithm="md5",
+        )
+        self.assertEqual(src.clean_url, src.download_url)
+        self.assertIsNone(src.username)
+        self.assertIsNone(src.token)
 
-            # Use any_order=False to ensure the conversation happened in the right sequence
-            mock_send_command.assert_has_calls(expected_calls, any_order=False)
+        # Scenario: First verify_file fails (needs copy), second verify_file succeeds (copy worked)
+        mock_verify.side_effect = [False, True]
 
-            # Verify it didn't loop more times than necessary
-            self.assertEqual(mock_send_command.call_count, 7)
+        # Simulate the prompt sequence:
+        # 1. Initial command -> gets "Address or name of remote host"
+        # 2. Responds with "" -> gets "Copy complete"
+        self.device.native.send_command.side_effect = [
+            "Address or name of remote host [1.1.1.1]?",
+            "123456 bytes copied in 10.2 secs. Copy complete.",
+        ]
+        self.device.native.find_prompt.return_value = "Router#"
+
+        with self.subTest("Test successful copy with interactive prompts"):
+            self.device.remote_file_copy(src, file_system="flash:")
+
+            # Verify the command sent was correct
+            self.device.native.send_command.assert_any_call(
+                "copy sftp://1.1.1.1/test.bin flash:test.bin", expect_string=mock.ANY, read_timeout=900
+            )
+            self.device.native.send_command.assert_has_calls(
+                [
+                    mock.call("copy sftp://1.1.1.1/test.bin flash:test.bin", expect_string=mock.ANY, read_timeout=900),
+                    mock.call(
+                        "", expect_string=mock.ANY, read_timeout=900, cmd_verify=True
+                    ),  # Respond to "Address or name of remote host"
+                ]
+            )
+
+    def test_remote_file_copy_type_error(self):
+        with self.subTest("Test raises TypeError if src is not FileCopyModel"):
+            with self.assertRaises(TypeError):
+                self.device.remote_file_copy("not_a_model")
+
+    @mock.patch.object(IOSDevice, "verify_file")
+    def test_remote_file_copy_failure_on_error_output(self, mock_verify):
+        # Setup file model
+        src = FileCopyModel(
+            download_url="tftp://1.1.1.1/test.bin",
+            checksum="12345",
+            file_name="test.bin",
+            hashing_algorithm="md5",
+        )
+        mock_verify.return_value = False
+        self.device.native.find_prompt.return_value = "Router#"
+
+        # Simulate a network error returned by the device
+        self.device.native.send_command.return_value = "%Error opening tftp://1.1.1.1/test.bin (Timed out)"
+
+        with self.subTest("Test raises FileTransferError when device returns Error string"):
+            from pyntc.errors import FileTransferError
+
+            with self.assertRaises(FileTransferError):
+                self.device.remote_file_copy(src)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_devices/test_ios_device.py
+++ b/tests/unit/test_devices/test_ios_device.py
@@ -6,8 +6,10 @@ import mock
 import pytest
 
 from pyntc.devices import IOSDevice
+from pyntc.devices.ios_device import FileTransferURLPull, CiscoIosFileTransfer
 from pyntc.devices import ios_device as ios_module
 from pyntc.devices.base_device import RollbackError
+from pyntc.utils.models import FilePullSpec
 
 from .device_mocks.ios import send_command, send_command_expect
 
@@ -101,7 +103,7 @@ class TestIOSDevice(unittest.TestCase):
         self.assertTrue(result)
         self.device.native.send_command_timing.assert_any_call("copy running-config startup-config")
 
-    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
+    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
     def test_file_copy_remote_exists(self, mock_ft):
         self.device.native.send_command.side_effect = None
         self.device.native.send_command.return_value = "flash: /dev/null"
@@ -113,7 +115,7 @@ class TestIOSDevice(unittest.TestCase):
 
         self.assertTrue(result)
 
-    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
+    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
     def test_file_copy_remote_exists_bad_md5(self, mock_ft):
         self.device.native.send_command_timing.side_effect = None
         self.device.native.send_command.return_value = "flash: /dev/null"
@@ -125,7 +127,7 @@ class TestIOSDevice(unittest.TestCase):
 
         self.assertFalse(result)
 
-    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
+    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
     def test_file_copy_remote_exists_not(self, mock_ft):
         self.device.native.send_command_timing.side_effect = None
         self.device.native.send_command.return_value = "flash: /dev/null"
@@ -137,7 +139,7 @@ class TestIOSDevice(unittest.TestCase):
 
         self.assertFalse(result)
 
-    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
+    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
     @mock.patch.object(IOSDevice, "open")
     def test_file_copy(self, mock_open, mock_ft):
         self.device.native.send_command.side_effect = None
@@ -147,13 +149,13 @@ class TestIOSDevice(unittest.TestCase):
         mock_ft_instance.check_file_exists.side_effect = [False, True]
         self.device.file_copy("path/to/source_file")
 
-        mock_ft.assert_called_with(self.device.native, "path/to/source_file", "source_file", file_system="flash:")
+        mock_ft.assert_called_with(self.device.native, "path/to/source_file", "source_file", direction="put", file_system="flash:")
         mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()
         mock_open.assert_called_once()
 
-    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
+    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
     @mock.patch.object(IOSDevice, "open")
     def test_file_copy_different_dest(self, mock_open, mock_ft):
         self.device.native.send_command_timing.side_effect = None
@@ -163,13 +165,13 @@ class TestIOSDevice(unittest.TestCase):
         mock_ft_instance.check_file_exists.side_effect = [False, True]
         self.device.file_copy("source_file", "dest_file")
 
-        mock_ft.assert_called_with(self.device.native, "source_file", "dest_file", file_system="flash:")
+        mock_ft.assert_called_with(self.device.native, "source_file", "dest_file", direction="put", file_system="flash:")
         mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()
         mock_open.assert_called_once()
 
-    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
+    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
     @mock.patch.object(IOSDevice, "open")
     def test_file_copy_fail(self, mock_open, mock_ft):
         self.device.native.send_command_timing.side_effect = None
@@ -183,7 +185,7 @@ class TestIOSDevice(unittest.TestCase):
 
         mock_open.assert_not_called()
 
-    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
+    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
     @mock.patch.object(IOSDevice, "open")
     def test_file_copy_socket_closed_good_md5(self, mock_open, mock_ft):
         self.device.native.send_command_timing.side_effect = None
@@ -195,14 +197,14 @@ class TestIOSDevice(unittest.TestCase):
 
         self.device.file_copy("path/to/source_file")
 
-        mock_ft.assert_called_with(self.device.native, "path/to/source_file", "source_file", file_system="flash:")
+        mock_ft.assert_called_with(self.device.native, "path/to/source_file", "source_file", direction="put", file_system="flash:")
         mock_ft_instance.enable_scp.assert_any_call()
         mock_ft_instance.establish_scp_conn.assert_any_call()
         mock_ft_instance.transfer_file.assert_any_call()
         mock_ft_instance.compare_md5.assert_has_calls([mock.call(), mock.call()])
         mock_open.assert_called_once()
 
-    @mock.patch("pyntc.devices.ios_device.FileTransfer", autospec=True)
+    @mock.patch("pyntc.devices.ios_device.FileTransferURLPull", autospec=True)
     @mock.patch.object(IOSDevice, "open")
     def test_file_copy_fail_socket_closed_bad_md5(self, mock_open, mock_ft):
         self.device.native.send_command_timing.side_effect = None
@@ -412,6 +414,223 @@ class TestIOSDevice(unittest.TestCase):
         self.assertRaises(ios_module.OSInstallError, self.device.install_os, image_name=BOOT_IMAGE, install_mode=True)
         mock_wait.assert_not_called()
         mock_reboot.assert_not_called()
+
+
+class TestFileTransferURLPull(unittest.TestCase):
+
+    @mock.patch.object(IOSDevice, "open")
+    @mock.patch.object(IOSDevice, "close")
+    @mock.patch("netmiko.cisco.cisco_ios.CiscoIosSSH", autospec=True)
+    def setUp(self, mock_miko, mock_close, mock_open):
+        self.device = IOSDevice("host", "user", "pass")
+        mock_miko.send_command_timing.side_effect = send_command
+        mock_miko.send_command_expect.side_effect = send_command_expect
+        mock_miko.device_type = "cisco_ios"
+        self.device.native = mock_miko  # Mock the native connection for testing
+        self.source_file = FilePullSpec(
+            download_url="http://example.com/file.bin",
+            checksum="abc123",
+            file_name="file.bin",
+            hashing_algorithm="md5",
+            file_size=1024,
+            username="user",
+            token="pass",
+            vrf="VRF1",
+            ftp_passive=True,
+        )
+        self.dest_file = "file.bin"
+
+    def tearDown(self):
+        # Reset the mock so we don't have transient test effects
+        self.device.native.reset_mock()
+
+    def test_init(self):
+        ft = FileTransferURLPull(self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:")
+        self.assertEqual(ft.direction, "put") # The class should set direction to "put" if using url_pull as Netmiko only supports "put" or "get"
+        self.assertEqual(ft.source_file, self.source_file)
+        self.assertEqual(ft.dest_file, self.dest_file)
+        self.assertEqual(ft.source_md5, self.source_file.checksum)
+        self.assertIsNone(ft.source_sha512)
+        self.assertTrue(ft.pull_from_url)
+
+    def test_init_sha512(self):
+        self.source_file.hashing_algorithm = "sha512"
+        ft = FileTransferURLPull(self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:")
+        self.assertEqual(ft.direction, "put") # The class should set direction to "put" if using url_pull as Netmiko only supports "put" or "get"
+        self.assertEqual(ft.source_file, self.source_file)
+        self.assertIsNone(ft.source_md5)
+        self.assertEqual(ft.source_sha512, self.source_file.checksum)
+        self.assertTrue(ft.pull_from_url)
+
+    @mock.patch.object(CiscoIosFileTransfer, "transfer_file")
+    @mock.patch("pyntc.devices.ios_device.os", return_value=1024)
+    @mock.patch.object(FileTransferURLPull, "file_md5", return_value="abc123")
+    @mock.patch.object(FileTransferURLPull, "pull_file")
+    def test_transfer_file_pull_file(self, mock_pull_file, mock_file_md5, mock_os, mock_transfer_file):
+        ft = FileTransferURLPull(self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:")
+        ft.transfer_file()
+        mock_pull_file.assert_called_once()
+        mock_transfer_file.assert_not_called()
+
+    @mock.patch.object(CiscoIosFileTransfer, "transfer_file")
+    @mock.patch("pyntc.devices.ios_device.os", return_value=1024)
+    @mock.patch.object(FileTransferURLPull, "file_md5", return_value="abc123")
+    @mock.patch.object(FileTransferURLPull, "pull_file")
+    def test_transfer_file_transfer_file(self, mock_pull_file, mock_file_md5, mock_os, mock_transfer_file):
+        ft2 = FileTransferURLPull(self.device.native, "test1.txt", self.dest_file, direction="put", file_system="flash:")
+        ft2.transfer_file()
+        mock_pull_file.assert_not_called()
+        mock_transfer_file.assert_called_once()
+
+    @mock.patch.object(CiscoIosFileTransfer, "compare_md5")
+    @mock.patch.object(FileTransferURLPull, "remote_sha512", return_value="abc123")
+    @mock.patch("pyntc.devices.ios_device.os", return_value=1024)
+    @mock.patch.object(FileTransferURLPull, "file_md5", return_value="abc123")
+    @mock.patch.object(FileTransferURLPull, "pull_file")
+    def test_compare_md5_sha512(self, mock_pull_file, mock_file_md5, mock_os, mock_remote_sha512, mock_compare_md5):
+        self.source_file.hashing_algorithm = "sha512"
+        ft = FileTransferURLPull(self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:")
+        ft.compare_md5()
+        mock_compare_md5.assert_not_called()
+        mock_remote_sha512.assert_called_once()
+
+    @mock.patch.object(CiscoIosFileTransfer, "compare_md5")
+    @mock.patch.object(FileTransferURLPull, "remote_sha512", return_value="abc123")
+    @mock.patch("pyntc.devices.ios_device.os", return_value=1024)
+    @mock.patch.object(FileTransferURLPull, "file_md5", return_value="abc123")
+    @mock.patch.object(FileTransferURLPull, "pull_file")
+    def test_compare_md5(self, mock_pull_file, mock_file_md5, mock_os, mock_remote_sha512, mock_compare_md5):
+        ft = FileTransferURLPull(self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:")
+        ft.compare_md5()
+        mock_compare_md5.assert_called_once()
+        mock_remote_sha512.assert_not_called()
+
+    def test_remote_sha512(self):
+        ft = FileTransferURLPull(self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:")
+        with mock.patch.object(self.device.native, "_send_command_str", return_value="= abc123") as mock_send_command:
+            result = ft.remote_sha512()
+            mock_send_command.assert_called_once_with("verify /sha512 flash:/file.bin", read_timeout=300)
+            self.assertEqual(result, "abc123")
+
+
+    def test_pull_file(self):
+        self.device.native.find_prompt.return_value = "router#"
+        ft = FileTransferURLPull(self.device.native, self.source_file, self.dest_file, direction="url_pull", file_system="flash:")
+        with mock.patch.object(self.device.native, "send_command", return_value="copy http://example.com/file.bin flash:/file.bin\nCopy complete\nrouter#") as mock_send_command:
+            ft.pull_file()
+            mock_send_command.assert_called_once_with(
+                "copy http://example.com/file.bin flash:file.bin", # HTTP does not use VRF in the command
+                expect_string="(Destination filename|router\\#|confirm|Password|Address or name of remote host|Source username|Source filename|yes/no|Are you sure you want to continue connecting)",
+                read_timeout=300,
+            )
+        source_file = FilePullSpec(
+            download_url="sftp://example.com/file.bin",
+            checksum="abc123",
+            file_name="file.bin",
+            hashing_algorithm="md5",
+            file_size=1024,
+            username="user",
+            token="pass",
+            vrf="VRF1",
+            ftp_passive=True,
+        )
+        ft2 = FileTransferURLPull(self.device.native, source_file=source_file, dest_file=self.dest_file, direction="url_pull", file_system="flash:")
+        with mock.patch.object(self.device.native, "send_command", return_value="copy sftp://example.com/file.bin flash:file.bin vrf VRF1\nCopy complete\nrouter#") as mock_send_command:
+            ft2.pull_file()
+            mock_send_command.assert_called_once_with(
+                "copy sftp://example.com/file.bin flash:file.bin vrf VRF1",
+                expect_string="(Destination filename|router\\#|confirm|Password|Address or name of remote host|Source username|Source filename|yes/no|Are you sure you want to continue connecting)",
+                read_timeout=300,
+            )
+
+    def test_pull_file_all_prompts(self):
+        self.device.native.find_prompt.return_value = "router#"
+        source_file = FilePullSpec(
+            download_url="sftp://example.com/file.bin",
+            checksum="abc123",
+            file_name="file.bin",
+            hashing_algorithm="md5",
+            file_size=1024,
+            username="user",
+            token="pass",
+            vrf="VRF1",
+            ftp_passive=True,
+        )
+        ft = FileTransferURLPull(
+            self.device.native,
+            source_file=source_file,
+            dest_file=self.dest_file,
+            direction="url_pull",
+            file_system="flash:"
+        )
+        responses = [
+            "Address or name of remote host [example.com]?",
+            "Source username [user]?",
+            "Source filename [file.bin]?",
+            "Destination filename [file.bin]?",
+            "%Warning: There is a file already existing with this name\nDo you want to over write? [confirm]",
+            "Password: ",
+            "1024 bytes copied in 2 secs\nrouter#"
+        ]
+
+        # Shared expect_string to keep the assertion clean
+        expect_regex = r"(Destination filename|router\#|confirm|Password|Address or name of remote host|Source username|Source filename|yes/no|Are you sure you want to continue connecting)"
+
+        with mock.patch.object(self.device.native, "send_command", side_effect=responses) as mock_send_command:
+            ft.pull_file()
+
+            # Define the expected sequence of calls
+            expected_calls = [
+                # The initial copy command
+                mock.call(
+                    "copy sftp://example.com/file.bin flash:file.bin vrf VRF1",
+                    expect_string=expect_regex,
+                    read_timeout=300
+                ),
+                # The response to the "Address or name of remote host" prompt (sending a newline/empty string to accept the default)
+                mock.call(
+                    "",
+                    expect_string=expect_regex,
+                    read_timeout=300
+                ),
+                # The response to the "Source username" prompt (sending the username)
+                mock.call(
+                    "user",
+                    expect_string=expect_regex,
+                    read_timeout=300
+                ),
+                # The response to the "Source filename" prompt (sending a newline/empty string to accept the default)
+                mock.call(
+                    "",
+                    expect_string=expect_regex,
+                    read_timeout=300
+                ),
+                # The response to the "Destination filename" prompt (sending a newline/empty string to accept the default)
+                mock.call(
+                    "",
+                    expect_string=expect_regex,
+                    read_timeout=300
+                ),
+                # The response to the confirm overwrite prompt (sending a newline/empty string to accept)
+                mock.call(
+                    "",
+                    expect_string=expect_regex,
+                    read_timeout=300
+                ),
+                # The response to the Password prompt
+                mock.call(
+                    "pass",
+                    expect_string=expect_regex,
+                    read_timeout=300,
+                    cmd_verify=False  # Don't verify the command for password input
+                ),
+            ]
+
+            # Use any_order=False to ensure the conversation happened in the right sequence
+            mock_send_command.assert_has_calls(expected_calls, any_order=False)
+
+            # Verify it didn't loop more times than necessary
+            self.assertEqual(mock_send_command.call_count, 7)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR add the ability to have the Cisco IOS devices download the files instead of relying on copying the files to the device through scp.  I am using the dataclass FilePullSpec to simplify the required arguments when downloading the files instead of copying them through scp. 