### PR TITLE
Removed unneeded warning filter and logging

### DIFF
--- a/changes/364.removed
+++ b/changes/364.removed
@@ -1,0 +1,2 @@
+Removed log.init from iosxewlc device.
+Removed warning filter for logging.

--- a/pyntc/__init__.py
+++ b/pyntc/__init__.py
@@ -1,7 +1,6 @@
 """Kickoff functions for getting instance of device objects."""
 
 import os
-import warnings
 from importlib import metadata
 
 from .devices import supported_devices
@@ -21,9 +20,6 @@ __version__ = metadata.version(__name__)
 
 LIB_PATH_ENV_VAR = "PYNTC_CONF"
 LIB_PATH_DEFAULT = "~/.ntc.conf"
-
-
-warnings.simplefilter("default")
 
 
 def ntc_device(device_type, *args, **kwargs):

--- a/pyntc/devices/iosxewlc_device.py
+++ b/pyntc/devices/iosxewlc_device.py
@@ -12,8 +12,6 @@ INSTALL_MODE_FILE_NAME = "packages.conf"
 class IOSXEWLCDevice(IOSDevice):
     """Cisco IOSXE WLC Device Implementation."""
 
-    log.init()
-
     def _wait_for_device_start_reboot(self, timeout=600):
         start = time.time()
         while time.time() - start < timeout:


### PR DESCRIPTION
## New Pull Request

## Change Notes
Removes warning filter
Removes log init from isoxewlc device

## Justification
These were creating unneeded logs when using the package.