### PR TITLE
Added remote_file_copy support for ASADevice (FTP, TFTP, SCP, HTTP, HTTPS)

### DIFF
--- a/changes/366.added
+++ b/changes/366.added
@@ -1,0 +1,1 @@
+Added ``remote_file_copy``, ``check_file_exists``, ``get_remote_checksum``, and ``verify_file`` support for ``ASADevice`` (FTP, TFTP, SCP, HTTP, HTTPS).

--- a/changes/366.fixed
+++ b/changes/366.fixed
@@ -1,0 +1,3 @@
+Fixed ``ASADevice._get_file_system`` to use ``re.search`` instead of ``re.match`` so the filesystem label is correctly parsed regardless of leading whitespace in ``dir`` output.
+Fixed ``ASADevice._send_command`` to anchor the ``%`` error pattern to the start of a line (``^% ``) to prevent false-positive ``CommandError`` raises during file copy operations.
+Fixed ``ASADevice.active_redundancy_states`` to include ``"disabled"`` so standalone (non-failover) units are correctly treated as active.

--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -5,7 +5,7 @@ import re
 import time
 from collections import Counter
 from ipaddress import IPv4Address, IPv4Interface, IPv6Address, IPv6Interface, ip_address
-from typing import Dict, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 from urllib.parse import urlparse
 
 from netmiko import ConnectHandler
@@ -382,7 +382,7 @@ class ASADevice(BaseDevice):
         log.debug("Host %s: the boot options are %s", self.host, {"sys": boot_image})
         return {"sys": boot_image}
 
-    def check_file_exists(self, filename, **kwargs):
+    def check_file_exists(self, filename, **kwargs: Any):
         """Check whether a file exists on the device.
 
         Args:
@@ -609,7 +609,7 @@ class ASADevice(BaseDevice):
         log.debug("Host %s: File %s does not already exist on remote.", self.host, src)
         return False
 
-    def get_remote_checksum(self, filename, hashing_algorithm="md5", **kwargs):
+    def get_remote_checksum(self, filename, hashing_algorithm="md5", **kwargs: Any):
         """Get the checksum of a file on the device.
 
         Args:
@@ -996,7 +996,7 @@ class ASADevice(BaseDevice):
 
         log.debug("Host %s: reboot standby with timeout %s.", self.host, timeout)
 
-    def remote_file_copy(self, src: FileCopyModel = None, dest=None, **kwargs):
+    def remote_file_copy(self, src: FileCopyModel = None, dest=None, **kwargs: Any):
         """Copy a file from a remote server to the device.
 
         Pulls the file specified by ``src`` from a remote server using the protocol in
@@ -1261,7 +1261,7 @@ class ASADevice(BaseDevice):
         """
         return self.show("show startup-config")
 
-    def verify_file(self, checksum, filename, hashing_algorithm="md5", **kwargs):
+    def verify_file(self, checksum, filename, hashing_algorithm="md5", **kwargs: Any):
         """Verify a file on the device by comparing checksums.
 
         Args:

--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -6,6 +6,7 @@ import time
 from collections import Counter
 from ipaddress import IPv4Address, IPv4Interface, IPv6Address, IPv6Interface, ip_address
 from typing import Dict, Iterable, List, Optional, Union
+from urllib.parse import urlparse
 
 from netmiko import ConnectHandler
 from netmiko.cisco import CiscoAsaFileTransfer, CiscoAsaSSH
@@ -24,7 +25,9 @@ from pyntc.errors import (
     RebootTimeoutError,
 )
 from pyntc.utils import get_structured_data
+from pyntc.utils.models import FileCopyModel
 
+ASA_HASHING_ALGORITHM_MAP = {"md5": "md5", "sha512": "sha-512"}
 RE_SHOW_FAILOVER_GROUPS = re.compile(r"Group\s+\d+\s+State:\s+(.+?)\s*$", re.M)
 RE_SHOW_FAILOVER_STATE = re.compile(r"(?:Primary|Secondary)\s+-\s+(.+?)\s*$", re.M)
 RE_SHOW_IP_ADDRESS = re.compile(r"^\S+\s+(\S+)\s+((?:\d+.){3}\d+)\s+((?:\d+.){3}\d+)", re.M)
@@ -36,7 +39,7 @@ class ASADevice(BaseDevice):
     """Cisco ASA Device Implementation."""
 
     vendor = "cisco"
-    active_redundancy_states = {None, "active"}
+    active_redundancy_states = {None, "active", "disabled"}
 
     # pylint: disable=too-many-arguments, too-many-positional-arguments
     def __init__(self, host: str, username: str, password: str, secret="", port=None, **kwargs):  # nosec
@@ -125,7 +128,7 @@ class ASADevice(BaseDevice):
         """
         raw_data = self.show("dir")
         try:
-            file_system = re.match(r"\s*.*?(\S+:)", raw_data).group(1)
+            file_system = re.search(r"(\S+:)", raw_data).group(1)
 
         except AttributeError:
             # TODO: Get proper hostname
@@ -249,7 +252,7 @@ class ASADevice(BaseDevice):
         else:
             response = self.native.send_command(command, expect_string=expect_string)
 
-        if "% " in response or "Error:" in response:
+        if re.search(r"^% ", response, re.MULTILINE) or "Error:" in response:
             log.error("Host %s: Error in %s with response: %s", self.host, command, response)
             raise CommandError(command, response)
 
@@ -378,6 +381,30 @@ class ASADevice(BaseDevice):
 
         log.debug("Host %s: the boot options are %s", self.host, {"sys": boot_image})
         return {"sys": boot_image}
+
+    def check_file_exists(self, filename, **kwargs):
+        """Check whether a file exists on the device.
+
+        Args:
+            filename (str): The name of the file to check for on the device.
+            **kwargs: Optional keyword arguments.
+
+        Keyword Args:
+            file_system (str): The file system to check. Defaults to ``_get_file_system()``.
+
+        Returns:
+            (bool): True if the file exists, False otherwise.
+        """
+        file_system = kwargs.get("file_system") or self._get_file_system()
+        cmd = f"dir {file_system}{filename}"
+        result = self.native.send_command(cmd, read_timeout=30)
+
+        if re.search(r"No such file or directory|ERROR:", result, re.IGNORECASE):
+            log.debug("Host %s: File %s does not exist on %s.", self.host, filename, file_system)
+            return False
+
+        log.debug("Host %s: File %s exists on %s.", self.host, filename, file_system)
+        return bool(re.search(re.escape(filename), result))
 
     def checkpoint(self, checkpoint_file):
         """
@@ -581,6 +608,45 @@ class ASADevice(BaseDevice):
 
         log.debug("Host %s: File %s does not already exist on remote.", self.host, src)
         return False
+
+    def get_remote_checksum(self, filename, hashing_algorithm="md5", **kwargs):
+        """Get the checksum of a file on the device.
+
+        Args:
+            filename (str): The name of the file on the device.
+            hashing_algorithm (str): The hashing algorithm to use. Valid choices are ``"md5"`` and
+                ``"sha512"`` (default: ``"md5"``).
+            **kwargs: Optional keyword arguments.
+
+        Keyword Args:
+            file_system (str): The file system where the file resides. Defaults to ``_get_file_system()``.
+
+        Returns:
+            (str): The checksum of the file.
+
+        Raises:
+            ValueError: If an unsupported hashing algorithm is provided.
+            CommandError: If the checksum cannot be parsed from the device output.
+        """
+        asa_algorithm = ASA_HASHING_ALGORITHM_MAP.get(hashing_algorithm)
+
+        if asa_algorithm is None:
+            raise ValueError(
+                f"hashing_algorithm must be 'md5' or 'sha512' for Cisco ASA devices, got '{hashing_algorithm}'."
+            )
+
+        file_system = kwargs.get("file_system") or self._get_file_system()
+        cmd = f"verify /{asa_algorithm} {file_system}{filename}"
+        result = self.native.send_command_timing(cmd, read_timeout=300)
+
+        if match := re.search(r"=\s+(\S+)", result):
+            log.debug(
+                "Host %s: Remote checksum for %s using %s is %s.", self.host, filename, hashing_algorithm, match[1]
+            )
+            return match[1]
+
+        log.error("Host %s: Unable to parse checksum for %s from output: %s", self.host, filename, result)
+        raise CommandError(cmd, f"Unable to parse checksum for {filename}")
 
     def install_os(self, image_name, **vendor_specifics):
         """
@@ -930,6 +996,83 @@ class ASADevice(BaseDevice):
 
         log.debug("Host %s: reboot standby with timeout %s.", self.host, timeout)
 
+    def remote_file_copy(self, src: FileCopyModel = None, dest=None, **kwargs):
+        """Copy a file from a remote server to the device.
+
+        Pulls the file specified by ``src`` from a remote server using the protocol in
+        ``src.download_url`` (FTP, TFTP, SCP, HTTP, or HTTPS) and saves it to the device
+        filesystem. The file is verified after transfer using the checksum in ``src``.
+
+        SFTP is not supported on Cisco ASA devices.
+
+        Args:
+            src (FileCopyModel): Specification of the source file including URL, checksum, and
+                credentials.
+            dest (str): Filename to use on the device. Defaults to ``src.file_name``.
+            **kwargs: Optional keyword arguments.
+
+        Keyword Args:
+            file_system (str): Destination file system on the device (e.g. ``"disk0:"``).
+                Defaults to ``_get_file_system()``.
+
+        Raises:
+            TypeError: If ``src`` is not a ``FileCopyModel`` instance.
+            FileTransferError: If the transfer fails or the file cannot be verified afterwards.
+        """
+        if not isinstance(src, FileCopyModel):
+            raise TypeError("src must be an instance of FileCopyModel")
+
+        file_system = kwargs.get("file_system") or self._get_file_system()
+
+        if dest is None:
+            dest = src.file_name
+
+        if not self.verify_file(src.checksum, dest, hashing_algorithm=src.hashing_algorithm, file_system=file_system):
+            current_prompt = self.native.find_prompt()
+            prompt_answers = {
+                r"Password": src.token,
+                r"Source username": src.username,
+                r"yes/no|Are you sure you want to continue connecting": "yes",
+                r"(confirm|Address or name of remote host|Source filename|Destination filename)": "",
+            }
+            keys = list(prompt_answers.keys()) + [re.escape(current_prompt)]
+            expect_regex = f"({'|'.join(keys)})"
+            src_url = src.clean_url
+
+            if not urlparse(src.clean_url).path.strip("/"):
+                src_url = f"{src.clean_url.rstrip('/')}/{dest}"
+
+            command = f"copy {src_url} {file_system}{dest}"
+
+            if src.vrf and src.scheme not in {"http", "https"}:
+                command = f"{command} vrf {src.vrf}"
+
+            # Bypass _send_command — copy output may contain "% " patterns that are not failures
+            output = self.native.send_command(command, expect_string=expect_regex, read_timeout=src.timeout)
+
+            while current_prompt not in output:
+                if re.search(r"bytes copied in", output, re.IGNORECASE):
+                    log.info("Host %s: File %s transferred successfully.", self.host, src.file_name)
+                    break
+
+                if re.search(r"(Error|Invalid|Failed|Aborted|denied)", output, re.IGNORECASE):
+                    log.error("Host %s: File transfer error for %s: %s", self.host, src.file_name, output)
+                    raise FileTransferError
+
+                for prompt, answer in prompt_answers.items():
+                    if re.search(prompt, output, re.IGNORECASE):
+                        output = self.native.send_command(
+                            answer,
+                            expect_string=expect_regex,
+                            read_timeout=src.timeout,
+                            cmd_verify="Password" not in prompt,
+                        )
+                        break
+
+        if not self.verify_file(src.checksum, dest, hashing_algorithm=src.hashing_algorithm, file_system=file_system):
+            log.error("Host %s: File %s could not be verified after transfer.", self.host, src.file_name)
+            raise FileTransferError
+
     @property
     def redundancy_mode(self):
         """
@@ -1117,6 +1260,26 @@ class ASADevice(BaseDevice):
         :return: Output of command 'show startup-config'.
         """
         return self.show("show startup-config")
+
+    def verify_file(self, checksum, filename, hashing_algorithm="md5", **kwargs):
+        """Verify a file on the device by comparing checksums.
+
+        Args:
+            checksum (str): The expected checksum of the file.
+            filename (str): The name of the file on the device.
+            hashing_algorithm (str): The hashing algorithm to use (default: ``"md5"``).
+            **kwargs: Optional keyword arguments passed through to ``check_file_exists`` and
+                ``compare_file_checksum``.
+
+        Keyword Args:
+            file_system (str): The file system where the file resides. Defaults to ``_get_file_system()``.
+
+        Returns:
+            (bool): True if the file exists and the checksum matches, False otherwise.
+        """
+        return self.check_file_exists(filename, **kwargs) and self.compare_file_checksum(
+            checksum, filename, hashing_algorithm, **kwargs
+        )
 
     @property
     def uptime(self):

--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -27,7 +27,7 @@ from pyntc.errors import (
 from pyntc.utils import get_structured_data
 from pyntc.utils.models import FileCopyModel
 
-ASA_HASHING_ALGORITHM_MAP = {"md5": "md5", "sha512": "sha-512"}
+ASA_HASHING_ALGORITHM_MAP = {"md5": "md5", "sha512": "sha-512", "sha-512": "sha-512"}
 RE_SHOW_FAILOVER_GROUPS = re.compile(r"Group\s+\d+\s+State:\s+(.+?)\s*$", re.M)
 RE_SHOW_FAILOVER_STATE = re.compile(r"(?:Primary|Secondary)\s+-\s+(.+?)\s*$", re.M)
 RE_SHOW_IP_ADDRESS = re.compile(r"^\S+\s+(\S+)\s+((?:\d+.){3}\d+)\s+((?:\d+.){3}\d+)", re.M)
@@ -630,9 +630,9 @@ class ASADevice(BaseDevice):
         """
         asa_algorithm = ASA_HASHING_ALGORITHM_MAP.get(hashing_algorithm)
 
-        if asa_algorithm is None:
+        if not asa_algorithm:
             raise ValueError(
-                f"hashing_algorithm must be 'md5' or 'sha512' for Cisco ASA devices, got '{hashing_algorithm}'."
+                f"hashing_algorithm must be 'md5', 'sha512' or 'sha-512' for Cisco ASA devices, got '{hashing_algorithm}'."
             )
 
         file_system = kwargs.get("file_system") or self._get_file_system()
@@ -1024,7 +1024,7 @@ class ASADevice(BaseDevice):
 
         file_system = kwargs.get("file_system") or self._get_file_system()
 
-        if dest is None:
+        if not dest:
             dest = src.file_name
 
         if not self.verify_file(src.checksum, dest, hashing_algorithm=src.hashing_algorithm, file_system=file_system):

--- a/pyntc/devices/asa_device.py
+++ b/pyntc/devices/asa_device.py
@@ -1030,8 +1030,8 @@ class ASADevice(BaseDevice):
         if not self.verify_file(src.checksum, dest, hashing_algorithm=src.hashing_algorithm, file_system=file_system):
             current_prompt = self.native.find_prompt()
             prompt_answers = {
-                r"Password": src.token,
-                r"Source username": src.username,
+                r"Password": src.token or "",
+                r"Source username": src.username or "",
                 r"yes/no|Are you sure you want to continue connecting": "yes",
                 r"(confirm|Address or name of remote host|Source filename|Destination filename)": "",
             }
@@ -1068,10 +1068,17 @@ class ASADevice(BaseDevice):
                             cmd_verify="Password" not in prompt,
                         )
                         break
+                else:
+                    log.error(
+                        "Host %s: Unexpected output during file transfer of %s: %s", self.host, src.file_name, output
+                    )
+                    raise FileTransferError
 
-        if not self.verify_file(src.checksum, dest, hashing_algorithm=src.hashing_algorithm, file_system=file_system):
-            log.error("Host %s: File %s could not be verified after transfer.", self.host, src.file_name)
-            raise FileTransferError
+            if not self.verify_file(
+                src.checksum, dest, hashing_algorithm=src.hashing_algorithm, file_system=file_system
+            ):
+                log.error("Host %s: File %s could not be verified after transfer.", self.host, src.file_name)
+                raise FileTransferError
 
     @property
     def redundancy_mode(self):

--- a/tests/integration/test_asa_device.py
+++ b/tests/integration/test_asa_device.py
@@ -8,12 +8,12 @@ Usage (from project root):
     export ASA_USER=<user>
     export ASA_PASS=<pass>
     export ASA_SECRET=<enable_pass>
-    export FTP_URL=ftp://<ftp_user>:<ftp_password>@<server_ip>/<file_name> \\
-    export TFTP_URL=tftp://<server_ip>/<file_name> \\
-    export SCP_URL=scp://<scp_user>:<scp_password>@<server_ip>:2222/<file_name> \\
-    export HTTP_URL=http://<http_user>:<http_password>@<server_ip>:8081/<file_name> \\
-    export HTTPS_URL=https://<https_user>:<https_password>@<server_ip>:8443/<file_name> \\
-    export FILE_CHECKSUM=<sha512_hash> \\
+    export FTP_URL=ftp://<ftp_user>:<ftp_password>@<server_ip>/<file_name>
+    export TFTP_URL=tftp://<server_ip>/<file_name>
+    export SCP_URL=scp://<scp_user>:<scp_password>@<server_ip>:2222/<file_name>
+    export HTTP_URL=http://<http_user>:<http_password>@<server_ip>:8081/<file_name>
+    export HTTPS_URL=https://<https_user>:<https_password>@<server_ip>:8443/<file_name>
+    export FILE_CHECKSUM=<sha512_hash>
     poetry run pytest tests/integration/test_asa_device.py -v
 
 Set only the protocol URL vars for the servers you have available; each

--- a/tests/integration/test_asa_device.py
+++ b/tests/integration/test_asa_device.py
@@ -1,0 +1,186 @@
+"""Integration tests for ASADevice.remote_file_copy.
+
+These tests connect to an actual Cisco ASA device in the lab and are run manually.
+They are NOT part of the CI unit test suite.
+
+Usage (from project root):
+    export ASA_HOST=<asa_ip>
+    export ASA_USER=<user>
+    export ASA_PASS=<pass>
+    export ASA_SECRET=<enable_pass>
+    export FTP_URL=ftp://<ftp_user>:<ftp_password>@<server_ip>/<file_name> \\
+    export TFTP_URL=tftp://<server_ip>/<file_name> \\
+    export SCP_URL=scp://<scp_user>:<scp_password>@<server_ip>:2222/<file_name> \\
+    export HTTP_URL=http://<http_user>:<http_password>@<server_ip>:8081/<file_name> \\
+    export HTTPS_URL=https://<https_user>:<https_password>@<server_ip>:8443/<file_name> \\
+    export FILE_CHECKSUM=<sha512_hash> \\
+    poetry run pytest tests/integration/test_asa_device.py -v
+
+Set only the protocol URL vars for the servers you have available; each
+protocol test will skip automatically if its URL is not set.
+
+Environment variables:
+    ASA_HOST        - IP address or hostname of the lab ASA
+    ASA_USER        - SSH username
+    ASA_PASS        - SSH password
+    ASA_SECRET      - Enable password (can be same as ASA_PASS if not set)
+    FTP_URL         - FTP URL of the file to transfer
+    TFTP_URL        - TFTP URL of the file to transfer
+    SCP_URL         - SCP URL of the file to transfer
+    HTTP_URL        - HTTP URL of the file to transfer
+    HTTPS_URL       - HTTPS URL of the file to transfer
+    FILE_NAME       - Destination filename on the device (default: basename of URL path)
+    FILE_CHECKSUM   - Expected sha512 checksum of the file (shared across all protocols)
+"""
+
+import os
+import posixpath
+
+import pytest
+
+from pyntc.devices import ASADevice
+from pyntc.utils.models import FileCopyModel
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PROTOCOL_URL_VARS = {
+    "ftp": "FTP_URL",
+    "tftp": "TFTP_URL",
+    "scp": "SCP_URL",
+    "http": "HTTP_URL",
+    "https": "HTTPS_URL",
+}
+
+
+def _make_model(url_env_var):
+    """Build a FileCopyModel from a per-protocol URL env var.
+
+    Calls pytest.skip if the URL or FILE_CHECKSUM is not set.
+    """
+    url = os.environ.get(url_env_var)
+    checksum = os.environ.get("FILE_CHECKSUM")
+    file_name = os.environ.get("FILE_NAME") or (posixpath.basename(url.split("?")[0]) if url else None)
+
+    if not all([url, checksum, file_name]):
+        pytest.skip(f"{url_env_var} / FILE_CHECKSUM environment variables not set")
+
+    return FileCopyModel(
+        download_url=url,
+        checksum=checksum,
+        file_name=file_name,
+        hashing_algorithm="sha512",
+        timeout=900,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def device():
+    """Connect to the lab ASA. Skips all tests if credentials are not set."""
+    host = os.environ.get("ASA_HOST")
+    user = os.environ.get("ASA_USER")
+    password = os.environ.get("ASA_PASS")
+    secret = os.environ.get("ASA_SECRET", password)
+
+    if not all([host, user, password]):
+        pytest.skip("ASA_HOST / ASA_USER / ASA_PASS environment variables not set")
+
+    dev = ASADevice(host, user, password, secret=secret)
+    yield dev
+    dev.close()
+
+
+@pytest.fixture(scope="module")
+def any_file_copy_model():
+    """Return a FileCopyModel using the first available protocol URL.
+
+    Used by tests that only need a file reference (existence checks, checksum
+    verification) without caring about the transfer protocol.  Skips if no
+    protocol URL and FILE_CHECKSUM are set.
+    """
+    checksum = os.environ.get("FILE_CHECKSUM")
+    for env_var in _PROTOCOL_URL_VARS.values():
+        url = os.environ.get(env_var)
+        if url and checksum:
+            file_name = os.environ.get("FILE_NAME") or posixpath.basename(url.split("?")[0])
+            return FileCopyModel(
+                download_url=url,
+                checksum=checksum,
+                file_name=file_name,
+                hashing_algorithm="sha512",
+                timeout=900,
+            )
+    pytest.skip("No protocol URL / FILE_CHECKSUM environment variables not set")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_device_connects(device):
+    """Verify the device is reachable and in enable mode."""
+    assert device.is_active()
+
+
+def test_check_file_exists_false(device, any_file_copy_model):
+    """Before the copy, the file should not exist (or this test is a no-op if it does)."""
+    result = device.check_file_exists(any_file_copy_model.file_name)
+    # We just verify the method runs without error; state depends on lab environment
+    assert isinstance(result, bool)
+
+
+def test_get_remote_checksum_after_exists(device, any_file_copy_model):
+    """If the file already exists, verify get_remote_checksum returns a non-empty string."""
+    if not device.check_file_exists(any_file_copy_model.file_name):
+        pytest.skip("File does not exist on device; run test_remote_file_copy_* first")
+    checksum = device.get_remote_checksum(any_file_copy_model.file_name, hashing_algorithm="sha512")
+    assert checksum and len(checksum) > 0
+
+
+def test_remote_file_copy_ftp(device):
+    """Transfer the file using FTP and verify it exists on the device."""
+    model = _make_model("FTP_URL")
+    device.remote_file_copy(model)
+    assert device.check_file_exists(model.file_name)
+
+
+def test_remote_file_copy_tftp(device):
+    """Transfer the file using TFTP and verify it exists on the device."""
+    model = _make_model("TFTP_URL")
+    device.remote_file_copy(model)
+    assert device.check_file_exists(model.file_name)
+
+
+def test_remote_file_copy_scp(device):
+    """Transfer the file using SCP and verify it exists on the device."""
+    model = _make_model("SCP_URL")
+    device.remote_file_copy(model)
+    assert device.check_file_exists(model.file_name)
+
+
+def test_remote_file_copy_http(device):
+    """Transfer the file using HTTP and verify it exists on the device."""
+    model = _make_model("HTTP_URL")
+    device.remote_file_copy(model)
+    assert device.check_file_exists(model.file_name)
+
+
+def test_remote_file_copy_https(device):
+    """Transfer the file using HTTPS and verify it exists on the device."""
+    model = _make_model("HTTPS_URL")
+    device.remote_file_copy(model)
+    assert device.check_file_exists(model.file_name)
+
+
+def test_verify_file_after_copy(device, any_file_copy_model):
+    """After a successful copy the file should verify cleanly."""
+    if not device.check_file_exists(any_file_copy_model.file_name):
+        pytest.skip("File does not exist on device; run a copy test first")
+    assert device.verify_file(any_file_copy_model.checksum, any_file_copy_model.file_name, hashing_algorithm="sha512")

--- a/tests/unit/test_devices/test_asa_device.py
+++ b/tests/unit/test_devices/test_asa_device.py
@@ -1061,8 +1061,8 @@ def test_remote_file_copy_type_error(mock_verify, mock_fs, asa_device):
 @mock.patch.object(ASADevice, "verify_file", return_value=True)
 def test_remote_file_copy_already_exists(mock_verify, mock_fs, asa_device):
     asa_device.remote_file_copy(FILE_COPY_MODEL_FTP)
-    # verify_file is called twice: once as the pre-check (returns True) and once as the post-check
-    assert mock_verify.call_count == 2
+    # verify_file is called once (pre-check passes); post-check is skipped since no copy was needed
+    assert mock_verify.call_count == 1
     mock_verify.assert_any_call(SHA512_CHECKSUM, "asa.bin", hashing_algorithm="sha512", file_system="disk0:")
     asa_device.native.send_command.assert_not_called()
 
@@ -1137,6 +1137,16 @@ def test_remote_file_copy_verify_fails_after_copy(mock_verify, mock_fs, asa_devi
     with pytest.raises(FileTransferError):
         asa_device.remote_file_copy(FILE_COPY_MODEL_FTP)
     assert mock_verify.call_count == 2
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", return_value=False)
+def test_remote_file_copy_unmatched_output_raises(mock_verify, mock_fs, asa_device):
+    """Unexpected output that matches no known prompt or success/error pattern raises FileTransferError."""
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.return_value = "!!!!!!!!!! some unexpected banner line !!!!!!!!!!"
+    with pytest.raises(FileTransferError):
+        asa_device.remote_file_copy(FILE_COPY_MODEL_FTP)
 
 
 @mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")

--- a/tests/unit/test_devices/test_asa_device.py
+++ b/tests/unit/test_devices/test_asa_device.py
@@ -6,6 +6,8 @@ import pytest
 
 from pyntc.devices import ASADevice
 from pyntc.devices import asa_device as asa_module
+from pyntc.errors import FileTransferError
+from pyntc.utils.models import FileCopyModel
 
 from .device_mocks.asa import send_command
 
@@ -165,6 +167,7 @@ def test_enable_from_config(asa_device):
 
 def test_config(asa_device):
     command = "hostname DATA-CENTER-FW"
+    asa_device.native.send_command_timing.return_value = ""
 
     result = asa_device.config(command)
     assert result is None
@@ -183,6 +186,7 @@ def test_bad_config(asa_device):
 
 def test_config_list(asa_device):
     commands = ["crypto key generate rsa modulus 2048", "aaa authentication ssh console LOCAL"]
+    asa_device.native.send_command_timing.return_value = ""
     asa_device.config(commands)
 
     for cmd in commands:
@@ -279,11 +283,13 @@ def test_checkpoint(asa_device):
 
 
 def test_running_config(asa_device):
+    asa_device.native.send_command_timing.return_value = "interface eth1"
     expected = asa_device.show("show running config")
     assert asa_device.running_config == expected
 
 
 def test_starting_config(asa_device):
+    asa_device.native.send_command_timing.return_value = "interface eth1"
     expected = asa_device.show("show startup-config")
     assert asa_device.startup_config == expected
 
@@ -631,8 +637,9 @@ def test_ip_protocol(mock_ip_address, ip, ip_version, asa_device):
         (FAILED, False),
         (COLD_STANDBY, False),
         (None, True),
+        ("disabled", True),
     ),
-    ids=(ACTIVE, "standby_ready", NEGOTIATION, FAILED, "cold_standby", "unsupported"),
+    ids=(ACTIVE, "standby_ready", NEGOTIATION, FAILED, "cold_standby", "unsupported", "disabled"),
 )
 def test_is_active(mock_redundancy_state, asa_device, redundancy_state, expected):
     mock_redundancy_state.return_value = redundancy_state
@@ -899,3 +906,502 @@ def test_vlan(mock_get_vlans, asa_device):
 def test_port_none(patch):
     device = ASADevice("host", "user", "pass", port=None)
     assert device.port == 22
+
+
+# ---------------------------------------------------------------------------
+# check_file_exists tests
+# ---------------------------------------------------------------------------
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+def test_check_file_exists_returns_true(mock_fs, asa_device):
+    asa_device.native.send_command.return_value = "     -rwx  94038  Apr 13 2026 14:25  asa.bin\n"
+    result = asa_device.check_file_exists("asa.bin")
+    assert result is True
+    asa_device.native.send_command.assert_called_with("dir disk0:asa.bin", read_timeout=30)
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+def test_check_file_exists_returns_false(mock_fs, asa_device):
+    asa_device.native.send_command.return_value = "ERROR: disk0:/asa.bin: No such file or directory"
+    result = asa_device.check_file_exists("asa.bin")
+    assert result is False
+
+
+@mock.patch.object(ASADevice, "_get_file_system")
+def test_check_file_exists_uses_provided_file_system(mock_fs, asa_device):
+    asa_device.native.send_command.return_value = "     -rwx  94038  Apr 13 2026 14:25  asa.bin\n"
+    result = asa_device.check_file_exists("asa.bin", file_system="flash:")
+    assert result is True
+    asa_device.native.send_command.assert_called_with("dir flash:asa.bin", read_timeout=30)
+    mock_fs.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get_remote_checksum tests
+# ---------------------------------------------------------------------------
+
+MD5_CHECKSUM = "aabbccdd11223344aabbccdd11223344"
+SHA512_CHECKSUM = "90368777ae062ae6989272db08fa6c624601f841da5825b8ff1faaccd2c98b19ea4ca5"
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+def test_get_remote_checksum_md5(mock_fs, asa_device):
+    asa_device.native.send_command_timing.return_value = (
+        f"!!!!!!!!!!!!!!!!!!!!!!!!Done!\nverify /MD5 (disk0:/asa.bin) = {MD5_CHECKSUM}"
+    )
+    result = asa_device.get_remote_checksum("asa.bin")
+    assert result == MD5_CHECKSUM
+    asa_device.native.send_command_timing.assert_called_with("verify /md5 disk0:asa.bin", read_timeout=300)
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+def test_get_remote_checksum_sha512(mock_fs, asa_device):
+    asa_device.native.send_command_timing.return_value = (
+        f"!!!!!!!!!!!!!!!!!!!!!!!!Done!\nverify /SHA-512 (disk0:/asa.bin) = {SHA512_CHECKSUM}"
+    )
+    result = asa_device.get_remote_checksum("asa.bin", hashing_algorithm="sha512")
+    assert result == SHA512_CHECKSUM
+    asa_device.native.send_command_timing.assert_called_with("verify /sha-512 disk0:asa.bin", read_timeout=300)
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+def test_get_remote_checksum_uses_provided_file_system(mock_fs, asa_device):
+    asa_device.native.send_command_timing.return_value = (
+        f"!!!!!!!!!!!!!!!!!!!!!!!!Done!\nverify /MD5 (flash:/asa.bin) = {MD5_CHECKSUM}"
+    )
+    result = asa_device.get_remote_checksum("asa.bin", file_system="flash:")
+    assert result == MD5_CHECKSUM
+    asa_device.native.send_command_timing.assert_called_with("verify /md5 flash:asa.bin", read_timeout=300)
+    mock_fs.assert_not_called()
+
+
+def test_get_remote_checksum_invalid_algorithm(asa_device):
+    with pytest.raises(ValueError, match="hashing_algorithm must be"):
+        asa_device.get_remote_checksum("asa.bin", hashing_algorithm="sha256")
+
+
+# ---------------------------------------------------------------------------
+# verify_file tests
+# ---------------------------------------------------------------------------
+
+
+@mock.patch.object(ASADevice, "compare_file_checksum", return_value=True)
+@mock.patch.object(ASADevice, "check_file_exists", return_value=True)
+def test_verify_file_returns_true(mock_exists, mock_checksum, asa_device):
+    result = asa_device.verify_file(MD5_CHECKSUM, "asa.bin")
+    assert result is True
+    mock_exists.assert_called_once_with("asa.bin")
+    mock_checksum.assert_called_once_with(MD5_CHECKSUM, "asa.bin", "md5")
+
+
+@mock.patch.object(ASADevice, "check_file_exists", return_value=False)
+def test_verify_file_returns_false_not_exists(mock_exists, asa_device):
+    result = asa_device.verify_file(MD5_CHECKSUM, "asa.bin")
+    assert result is False
+    mock_exists.assert_called_once_with("asa.bin")
+
+
+@mock.patch.object(ASADevice, "compare_file_checksum", return_value=False)
+@mock.patch.object(ASADevice, "check_file_exists", return_value=True)
+def test_verify_file_returns_false_checksum_mismatch(mock_exists, mock_checksum, asa_device):
+    result = asa_device.verify_file("wrongchecksum", "asa.bin")
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# remote_file_copy tests
+# ---------------------------------------------------------------------------
+
+FILE_COPY_MODEL_FTP = FileCopyModel(
+    download_url="ftp://example-user:example-password@192.0.2.1/asa.bin",
+    checksum=SHA512_CHECKSUM,
+    file_name="asa.bin",
+    hashing_algorithm="sha512",
+    timeout=900,
+)
+FILE_COPY_MODEL_TFTP = FileCopyModel(
+    download_url="tftp://192.0.2.1/asa.bin",
+    checksum=SHA512_CHECKSUM,
+    file_name="asa.bin",
+    hashing_algorithm="sha512",
+    timeout=900,
+)
+FILE_COPY_MODEL_SCP = FileCopyModel(
+    download_url="scp://example-user:example-password@192.0.2.1/asa.bin",
+    checksum=SHA512_CHECKSUM,
+    file_name="asa.bin",
+    hashing_algorithm="sha512",
+    timeout=900,
+)
+FILE_COPY_MODEL_HTTP = FileCopyModel(
+    download_url="http://example-user:example-password@192.0.2.1/asa.bin",
+    checksum=SHA512_CHECKSUM,
+    file_name="asa.bin",
+    hashing_algorithm="sha512",
+    timeout=900,
+)
+FILE_COPY_MODEL_HTTPS = FileCopyModel(
+    download_url="https://example-user:example-password@192.0.2.1/asa.bin",
+    checksum=SHA512_CHECKSUM,
+    file_name="asa.bin",
+    hashing_algorithm="sha512",
+    timeout=900,
+)
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file")
+def test_remote_file_copy_type_error(mock_verify, mock_fs, asa_device):
+    with pytest.raises(TypeError):
+        asa_device.remote_file_copy("not_a_file_copy_model")
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", return_value=True)
+def test_remote_file_copy_already_exists(mock_verify, mock_fs, asa_device):
+    asa_device.remote_file_copy(FILE_COPY_MODEL_FTP)
+    # verify_file is called twice: once as the pre-check (returns True) and once as the post-check
+    assert mock_verify.call_count == 2
+    mock_verify.assert_any_call(SHA512_CHECKSUM, "asa.bin", hashing_algorithm="sha512", file_system="disk0:")
+    asa_device.native.send_command.assert_not_called()
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_success(mock_verify, mock_fs, asa_device):
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "Address or name of remote host [192.0.2.1]?",
+        "Source username [example-user]?",
+        "Source filename [asa.bin]?",
+        "Destination filename [asa.bin]?",
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_FTP)
+    assert mock_verify.call_count == 2
+    asa_device.native.send_command.assert_any_call(
+        "copy ftp://192.0.2.1/asa.bin disk0:asa.bin",
+        expect_string=mock.ANY,
+        read_timeout=900,
+    )
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_no_dest_defaults_to_file_name(mock_verify, mock_fs, asa_device):
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_FTP)
+    asa_device.native.send_command.assert_any_call(
+        "copy ftp://192.0.2.1/asa.bin disk0:asa.bin",
+        expect_string=mock.ANY,
+        read_timeout=900,
+    )
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_uses_provided_file_system(mock_verify, mock_fs, asa_device):
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_FTP, file_system="flash:")
+    mock_fs.assert_not_called()
+    asa_device.native.send_command.assert_any_call(
+        "copy ftp://192.0.2.1/asa.bin flash:asa.bin",
+        expect_string=mock.ANY,
+        read_timeout=900,
+    )
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", return_value=False)
+def test_remote_file_copy_error_in_output(mock_verify, mock_fs, asa_device):
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.return_value = "%Error opening ftp://192.0.2.1/asa.bin (Timed out)"
+    with pytest.raises(FileTransferError):
+        asa_device.remote_file_copy(FILE_COPY_MODEL_FTP)
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, False])
+def test_remote_file_copy_verify_fails_after_copy(mock_verify, mock_fs, asa_device):
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "94038 bytes copied in 0.90 secs",
+    ]
+    with pytest.raises(FileTransferError):
+        asa_device.remote_file_copy(FILE_COPY_MODEL_FTP)
+    assert mock_verify.call_count == 2
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_password_prompt_uses_cmd_verify_false(mock_verify, mock_fs, asa_device):
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "Password:",
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_FTP)
+    # The password response must be sent with cmd_verify=False
+    asa_device.native.send_command.assert_any_call(
+        FILE_COPY_MODEL_FTP.token,
+        expect_string=mock.ANY,
+        read_timeout=900,
+        cmd_verify=False,
+    )
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_confirm_prompt_uses_cmd_verify_true(mock_verify, mock_fs, asa_device):
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "Address or name of remote host [192.0.2.1]?",
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_FTP)
+    asa_device.native.send_command.assert_any_call(
+        "",
+        expect_string=mock.ANY,
+        read_timeout=900,
+        cmd_verify=True,
+    )
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_clean_url_used_in_command(mock_verify, mock_fs, asa_device):
+    """Credentials must be stripped from the copy command (clean_url used, not download_url)."""
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_FTP)
+    # clean_url strips credentials; raw download_url should NOT appear in the command
+    call_args = asa_device.native.send_command.call_args_list[0][0][0]
+    assert "example-user:example-password" not in call_args
+    assert "ftp://192.0.2.1/asa.bin" in call_args
+
+
+# ---------------------------------------------------------------------------
+# remote_file_copy TFTP tests
+# ---------------------------------------------------------------------------
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_tftp_success(mock_verify, mock_fs, asa_device):
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_TFTP)
+    assert mock_verify.call_count == 2
+    asa_device.native.send_command.assert_any_call(
+        "copy tftp://192.0.2.1/asa.bin disk0:asa.bin",
+        expect_string=mock.ANY,
+        read_timeout=900,
+    )
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_tftp_interactive_prompts(mock_verify, mock_fs, asa_device):
+    """TFTP has no credentials; confirmation prompts are answered with empty string."""
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "Address or name of remote host [192.0.2.1]?",
+        "Source filename [asa.bin]?",
+        "Destination filename [asa.bin]?",
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_TFTP)
+    asa_device.native.send_command.assert_any_call(
+        "",
+        expect_string=mock.ANY,
+        read_timeout=900,
+        cmd_verify=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# remote_file_copy SCP tests
+# ---------------------------------------------------------------------------
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_scp_success(mock_verify, mock_fs, asa_device):
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_SCP)
+    assert mock_verify.call_count == 2
+    asa_device.native.send_command.assert_any_call(
+        "copy scp://192.0.2.1/asa.bin disk0:asa.bin",
+        expect_string=mock.ANY,
+        read_timeout=900,
+    )
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_scp_ssh_host_key_prompt(mock_verify, mock_fs, asa_device):
+    """SCP SSH host-key verification prompt is answered with 'yes' and cmd_verify=True."""
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "Are you sure you want to continue connecting (yes/no)?",
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_SCP)
+    asa_device.native.send_command.assert_any_call(
+        "yes",
+        expect_string=mock.ANY,
+        read_timeout=900,
+        cmd_verify=True,
+    )
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_scp_password_prompt(mock_verify, mock_fs, asa_device):
+    """SCP password prompt sends token with cmd_verify=False."""
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "Password:",
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_SCP)
+    asa_device.native.send_command.assert_any_call(
+        FILE_COPY_MODEL_SCP.token,
+        expect_string=mock.ANY,
+        read_timeout=900,
+        cmd_verify=False,
+    )
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_scp_clean_url_used_in_command(mock_verify, mock_fs, asa_device):
+    """Credentials must be stripped from the SCP copy command."""
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_SCP)
+    call_args = asa_device.native.send_command.call_args_list[0][0][0]
+    assert "example-user:example-password" not in call_args
+    assert "scp://192.0.2.1/asa.bin" in call_args
+
+
+# ---------------------------------------------------------------------------
+# remote_file_copy HTTP tests
+# ---------------------------------------------------------------------------
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_http_success(mock_verify, mock_fs, asa_device):
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_HTTP)
+    assert mock_verify.call_count == 2
+    asa_device.native.send_command.assert_any_call(
+        "copy http://192.0.2.1/asa.bin disk0:asa.bin",
+        expect_string=mock.ANY,
+        read_timeout=900,
+    )
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_http_password_prompt(mock_verify, mock_fs, asa_device):
+    """HTTP password prompt sends token with cmd_verify=False."""
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "Password:",
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_HTTP)
+    asa_device.native.send_command.assert_any_call(
+        FILE_COPY_MODEL_HTTP.token,
+        expect_string=mock.ANY,
+        read_timeout=900,
+        cmd_verify=False,
+    )
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_http_clean_url_used_in_command(mock_verify, mock_fs, asa_device):
+    """Credentials must be stripped from the HTTP copy command."""
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_HTTP)
+    call_args = asa_device.native.send_command.call_args_list[0][0][0]
+    assert "example-user:example-password" not in call_args
+    assert "http://192.0.2.1/asa.bin" in call_args
+
+
+# ---------------------------------------------------------------------------
+# remote_file_copy HTTPS tests
+# ---------------------------------------------------------------------------
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_https_success(mock_verify, mock_fs, asa_device):
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_HTTPS)
+    assert mock_verify.call_count == 2
+    asa_device.native.send_command.assert_any_call(
+        "copy https://192.0.2.1/asa.bin disk0:asa.bin",
+        expect_string=mock.ANY,
+        read_timeout=900,
+    )
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_https_password_prompt(mock_verify, mock_fs, asa_device):
+    """HTTPS password prompt sends token with cmd_verify=False."""
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "Password:",
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_HTTPS)
+    asa_device.native.send_command.assert_any_call(
+        FILE_COPY_MODEL_HTTPS.token,
+        expect_string=mock.ANY,
+        read_timeout=900,
+        cmd_verify=False,
+    )
+
+
+@mock.patch.object(ASADevice, "_get_file_system", return_value="disk0:")
+@mock.patch.object(ASADevice, "verify_file", side_effect=[False, True])
+def test_remote_file_copy_https_clean_url_used_in_command(mock_verify, mock_fs, asa_device):
+    """Credentials must be stripped from the HTTPS copy command."""
+    asa_device.native.find_prompt.return_value = "asa5512#"
+    asa_device.native.send_command.side_effect = [
+        "94038 bytes copied in 0.90 secs",
+    ]
+    asa_device.remote_file_copy(FILE_COPY_MODEL_HTTPS)
+    call_args = asa_device.native.send_command.call_args_list[0][0][0]
+    assert "example-user:example-password" not in call_args
+    assert "https://192.0.2.1/asa.bin" in call_args


### PR DESCRIPTION
## Summary

Added `remote_file_copy` support to `ASADevice`, enabling file transfers from remote servers directly to Cisco ASA devices using FTP, TFTP, SCP, HTTP, and HTTPS protocols. SFTP is not supported on Cisco ASA devices.

This implementation also introduces three supporting methods — `check_file_exists`, `get_remote_checksum`, and `verify_file` — that enable pre- and post-transfer file verification.

Two additional bug fixes were included:
- Fixed `_get_file_system` to use `re.search` instead of `re.match` so it correctly parses filesystem identifiers from `dir` output regardless of leading whitespace.
- Fixed `_send_command` to use `re.search(r"^% ", ...)` with `re.MULTILINE` instead of a simple `in` check, preventing false-positive `CommandError` raises when `% ` appears in the middle of copy output.

Closes #1056

## Change Details

### New Methods on `ASADevice`

- **`check_file_exists(filename, **kwargs)`** — Runs `dir <file_system><filename>` and returns `True`/`False` based on whether the file is present. Accepts an optional `file_system` kwarg.
- **`get_remote_checksum(filename, hashing_algorithm="md5", **kwargs)`** — Runs `verify /<algorithm> <file_system><filename>` and parses the resulting hash. Supports `md5` and `sha512` (via `ASA_HASHING_ALGORITHM_MAP`). Raises `ValueError` for unsupported algorithms and `CommandError` if the output cannot be parsed.
- **`verify_file(checksum, filename, hashing_algorithm="md5", **kwargs)`** — Combines `check_file_exists` and `compare_file_checksum`. Returns `True` only if the file exists and its checksum matches.
- **`remote_file_copy(src: FileCopyModel, dest=None, **kwargs)`** — Orchestrates the full transfer workflow:
  1. Skips the copy if `verify_file` already passes (idempotent).
  2. Builds the `copy <url> <file_system><dest>` command, appending `vrf <vrf>` for FTP/TFTP/SCP when a VRF is configured.
  3. Handles interactive prompts (SSH host-key acceptance, username, password, confirmation) via a `send_command` loop, using `cmd_verify=False` for password prompts to avoid echo issues.
  4. Bypasses `_send_command` to avoid false-positive error detection on `% ` patterns that appear in normal copy output.
  5. Raises `FileTransferError` on transfer errors or post-transfer verification failure.

### Bug Fixes

- `_get_file_system`: changed `re.match` → `re.search` to handle ASA `dir` output where the filesystem label is not at the start of the string.
- `_send_command`: changed `"% " in response` → `re.search(r"^% ", response, re.MULTILINE)` to avoid false-positive errors during file copy operations.
- `active_redundancy_states`: added `"disabled"` to the set of states treated as active, covering standalone/non-failover ASA units that report `"disabled"` instead of `"active"`.

## Testing

### Unit Tests (32 new tests)

Covers all new methods, including:
- `check_file_exists`: file found, file not found, custom file system
- `get_remote_checksum`: MD5, SHA-512, custom file system, invalid algorithm
- `verify_file`: match, file not found, checksum mismatch
- `remote_file_copy`: already-exists skip, FTP/TFTP/SCP/HTTP/HTTPS success paths, interactive prompt handling (password, SSH host key, confirmation), custom `dest`, custom file system, error-in-output raises `FileTransferError`, post-transfer verification failure raises `FileTransferError`, `TypeError` on bad `src`

### Integration Tests (6 new tests)

Covers `check_file_exists`, `get_remote_checksum`, `remote_file_copy` for each protocol (FTP, TFTP, SCP, HTTP, HTTPS), and `verify_file` after copy.

## Checklist

- [x] Explanation of Change(s)
- [x] Added change log fragment (`changes/1056.added`)
- [ ] Attached Screenshots, Payload Example
- [x] Unit Tests
- [x] Integration Tests
- [ ] Documentation Updates
- [ ] Outline Remaining Work, Constraints from Design


## Integration Tests
```
% source .env && poetry run pytest tests/integration/test_asa_device.py -v           
================================================================== test session starts ===================================================================
platform darwin -- Python 3.12.11, pytest-9.0.3, pluggy-1.6.0 -- /Users/jameswilliams/Library/Caches/pypoetry/virtualenvs/pyntc-gs002iVE-py3.12/bin/python
cachedir: .pytest_cache
rootdir: /Users/jameswilliams/Documents/code/pyntc
configfile: pyproject.toml
plugins: f5-sdk-3.0.21, requests-mock-1.12.1
collected 9 items                                                                                                                                        
tests/integration/test_asa_device.py::test_device_connects PASSED                                                                                  [ 11%]
tests/integration/test_asa_device.py::test_check_file_exists_false PASSED                                                                          [ 22%]
tests/integration/test_asa_device.py::test_get_remote_checksum_after_exists PASSED                                                                 [ 33%]
tests/integration/test_asa_device.py::test_remote_file_copy_ftp PASSED                                                                             [ 44%]
tests/integration/test_asa_device.py::test_remote_file_copy_tftp PASSED                                                                            [ 55%]
tests/integration/test_asa_device.py::test_remote_file_copy_scp PASSED                                                                             [ 66%]
tests/integration/test_asa_device.py::test_remote_file_copy_http PASSED                                                                            [ 77%]
tests/integration/test_asa_device.py::test_remote_file_copy_https PASSED                                                                           [ 88%]
tests/integration/test_asa_device.py::test_verify_file_after_copy PASSED                                                                           [100%]
============================================================== 9 passed in 79.25s (0:01:19) ==============================================================
```