### PR TITLE
fix nxos install_os not exiting early if a reboot was not requested.

### DIFF
--- a/changes/380.fixed
+++ b/changes/380.fixed
@@ -1,0 +1,1 @@
+Fixed nxos install_os waiting for the device to reboot even if a reboot was not requested.

--- a/pyntc/devices/nxos_device.py
+++ b/pyntc/devices/nxos_device.py
@@ -637,6 +637,9 @@ class NXOSDevice(BaseDevice):
         if not self._image_booted(image_name):
             log.info("Host %s: Setting Image %s in boot options.", self.host, image_name)
             self.set_boot_options(image_name, reboot=reboot, **vendor_specifics)
+            if not reboot:
+                log.info("Host %s: OS image %s boot options set. Reboot the device to apply", self.host, image_name)
+                return True
             log.info("Host %s: Waiting for device reload.", self.host)
             self._wait_for_device_reboot(timeout=timeout)
             if not self._image_booted(image_name):


### PR DESCRIPTION
When testing OS upgrades against a nexus switch I noticed that it was waiting for the device to reboot when I disabled the reboot flag. This fixes that bug.