### PR TITLE
fix nxos install_os failing

### DIFF
--- a/changes/402.fixed
+++ b/changes/402.fixed
@@ -1,0 +1,1 @@
+Fixed nxos install_os failing due to using the default timeout on the long running `install all` command.

--- a/pyntc/devices/nxos_device.py
+++ b/pyntc/devices/nxos_device.py
@@ -896,10 +896,16 @@ class NXOSDevice(BaseDevice):
                 reboot_arg = " no-reload"
             try:
                 if kickstart is None:
-                    self.show_netmiko(f"install all nxos {image_name}{reboot_arg}", raw_text=True)
+                    self.show_netmiko(
+                        f"install all nxos {image_name}{reboot_arg}",
+                        read_timeout=3600,
+                        raw_text=True,
+                    )
                 else:
                     self.show_netmiko(
-                        f"install all system {image_name} kickstart {kickstart}{reboot_arg}", raw_text=True
+                        f"install all system {image_name} kickstart {kickstart}{reboot_arg}",
+                        read_timeout=3600,
+                        raw_text=True,
                     )
             except (NetmikoBaseException, NetmikoTimeoutException):
                 pass


### PR DESCRIPTION
Fix nxos install_os failing due to using the default timeout on the long running install command