### PR TITLE
Release v3.2.0 to develop

### DIFF
--- a/changes/400.added
+++ b/changes/400.added
@@ -1,2 +1,0 @@
-Added support for ISSU and NSSU non-disruptive OS upgrades on Juniper devices.
-Added a `snapshot` option to `JunosDevice.install_os` that takes a post-upgrade `request system snapshot slice alternate` and waits for completion; disabled by default because Junos does not require a snapshot to complete an upgrade.

--- a/changes/400.fixed
+++ b/changes/400.fixed
@@ -1,5 +1,0 @@
-Fixed `JunosDevice._get_free_space` raising `FileSystemNotFoundError` on virtual-chassis, multi-RE, and cluster devices; the smallest member's free space is now returned.
-Fixed `JunosDevice.remote_file_copy` discarding the device's actual error message on a failed copy; the underlying error is now included in the raised `FileTransferError`.
-Fixed `JunosDevice.remote_file_copy` failing with "filesystem is full" on small-flash platforms (e.g., EX switches); remote images are now downloaded directly to the destination path instead of being staged in the user's home directory on `/var`.
-Fixed `JunosDevice` post-install version verification failing on platforms whose `show version` output has no "JUNOS Base OS Software Suite" line (e.g., EX switches on 15.1).
-Fixed `JunosDevice.install_os` issuing a disruptive full-chassis reboot after an NSSU/ISSU upgrade, which already reboots each member in service during the install.

--- a/docs/admin/release_notes/version_3.2.md
+++ b/docs/admin/release_notes/version_3.2.md
@@ -1,0 +1,23 @@
+# v3.2 Release Notes
+
+This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Overview
+
+- Added support for ISSU and NSSU non-disruptive OS upgrades on Juniper devices, along with several fixes to Juniper `install_os` and `remote_file_copy` handling.
+
+<!-- towncrier release notes start -->
+## [v3.2.0 (2026-07-14)](https://github.com/networktocode/pyntc/releases/tag/v3.2.0)
+
+### Added
+
+- [#400](https://github.com/networktocode/pyntc/issues/400) - Added support for ISSU and NSSU non-disruptive OS upgrades on Juniper devices.
+- [#400](https://github.com/networktocode/pyntc/issues/400) - Added a `snapshot` option to `JunosDevice.install_os` that takes a post-upgrade `request system snapshot slice alternate` and waits for completion; disabled by default because Junos does not require a snapshot to complete an upgrade.
+
+### Fixed
+
+- [#400](https://github.com/networktocode/pyntc/issues/400) - Fixed `JunosDevice._get_free_space` raising `FileSystemNotFoundError` on virtual-chassis, multi-RE, and cluster devices; the smallest member's free space is now returned.
+- [#400](https://github.com/networktocode/pyntc/issues/400) - Fixed `JunosDevice.remote_file_copy` discarding the device's actual error message on a failed copy; the underlying error is now included in the raised `FileTransferError`.
+- [#400](https://github.com/networktocode/pyntc/issues/400) - Fixed `JunosDevice.remote_file_copy` failing with "filesystem is full" on small-flash platforms (e.g., EX switches); remote images are now downloaded directly to the destination path instead of being staged in the user's home directory on `/var`.
+- [#400](https://github.com/networktocode/pyntc/issues/400) - Fixed `JunosDevice` post-install version verification failing on platforms whose `show version` output has no "JUNOS Base OS Software Suite" line (e.g., EX switches on 15.1).
+- [#400](https://github.com/networktocode/pyntc/issues/400) - Fixed `JunosDevice.install_os` issuing a disruptive full-chassis reboot after an NSSU/ISSU upgrade, which already reboots each member in service during the install.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -132,6 +132,7 @@ nav:
       - Uninstall: "admin/uninstall.md"
       - Release Notes:
           - "admin/release_notes/index.md"
+          - v3.2: "admin/release_notes/version_3.2.md"
           - v3.1: "admin/release_notes/version_3.1.md"
           - v3.0: "admin/release_notes/version_3.0.md"
           - v2.4: "admin/release_notes/version_2.4.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyntc"
-version = "3.1.1a0"
+version = "3.2.0"
 description = "Python library focused on tasks related to device level and OS management."
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"
@@ -172,7 +172,7 @@ addopts = "-vv --doctest-modules -p no:warnings -p no:f5sdk_fixtures --ignore-gl
 [tool.towncrier]
 package = "pyntc"
 directory = "changes"
-filename = "docs/admin/release_notes/version_3.1.md"
+filename = "docs/admin/release_notes/version_3.2.md"
 template = "towncrier_template.j2"
 start_string = "<!-- towncrier release notes start -->"
 issue_format = "[#{issue}](https://github.com/networktocode/pyntc/issues/{issue})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyntc"
-version = "3.2.0"
+version = "3.2.1a0"
 description = "Python library focused on tasks related to device level and OS management."
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"


### PR DESCRIPTION
Post-release merge of `main` back into `develop` after publishing v3.2.0, including the `prepatch` version bump to `3.2.1a0`.

Merge as a **merge commit** (not squash).