### PR TITLE
Release v3.2.1 to develop

### DIFF
--- a/changes/407.fixed
+++ b/changes/407.fixed
@@ -1,1 +1,0 @@
-Fixed Arista EOS reboots not being detected when waiting for the device to reload.

--- a/docs/admin/release_notes/version_3.2.md
+++ b/docs/admin/release_notes/version_3.2.md
@@ -5,8 +5,15 @@ This document describes all new features and changes in the release. The format 
 ## Release Overview
 
 - Added support for ISSU and NSSU non-disruptive OS upgrades on Juniper devices, along with several fixes to Juniper `install_os` and `remote_file_copy` handling.
+- Fixed Arista EOS reboot detection when waiting for a device to reload.
 
 <!-- towncrier release notes start -->
+## [v3.2.1 (2026-07-27)](https://github.com/networktocode/pyntc/releases/tag/v3.2.1)
+
+### Fixed
+
+- [#407](https://github.com/networktocode/pyntc/issues/407) - Fixed Arista EOS reboots not being detected when waiting for the device to reload.
+
 ## [v3.2.0 (2026-07-14)](https://github.com/networktocode/pyntc/releases/tag/v3.2.0)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyntc"
-version = "3.2.1"
+version = "3.2.2a0"
 description = "Python library focused on tasks related to device level and OS management."
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyntc"
-version = "3.2.1a0"
+version = "3.2.1"
 description = "Python library focused on tasks related to device level and OS management."
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"


### PR DESCRIPTION
Merges the v3.2.1 release back into `develop` and bumps the version to `3.2.2a0`.

Merge as a **merge commit**, not a squash.