### PR TITLE
Release v3.2.2 to develop

### DIFF
--- a/changes/410.fixed
+++ b/changes/410.fixed
@@ -1,1 +1,0 @@
-Fixed checksum verification timing out on large OS images — `get_remote_checksum` and `verify_file` now accept a `read_timeout` argument and its default was raised from 300s to 900s for IOS, ASA and IOS-XR devices.

--- a/docs/admin/release_notes/version_3.2.md
+++ b/docs/admin/release_notes/version_3.2.md
@@ -8,6 +8,12 @@ This document describes all new features and changes in the release. The format 
 - Fixed Arista EOS reboot detection when waiting for a device to reload.
 
 <!-- towncrier release notes start -->
+## [v3.2.2 (2026-08-04)](https://github.com/networktocode/pyntc/releases/tag/v3.2.2)
+
+### Fixed
+
+- [#410](https://github.com/networktocode/pyntc/issues/410) - Fixed checksum verification timing out on large OS images — `get_remote_checksum` and `verify_file` now accept a `read_timeout` argument and its default was raised from 300s to 900s for IOS, ASA and IOS-XR devices.
+
 ## [v3.2.1 (2026-07-27)](https://github.com/networktocode/pyntc/releases/tag/v3.2.1)
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyntc"
-version = "3.2.2a0"
+version = "3.2.2"
 description = "Python library focused on tasks related to device level and OS management."
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyntc"
-version = "3.2.2"
+version = "3.2.3a0"
 description = "Python library focused on tasks related to device level and OS management."
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 readme = "README.md"


### PR DESCRIPTION
Merges `main` back into `develop` after the v3.2.2 release and bumps the version to `3.2.3a0`.