### PR TITLE
testing trusted publisher with no environment key usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,9 @@ jobs:
     runs-on: "ubuntu-latest"
     if: "startsWith(github.ref, 'refs/tags/v')"
     needs: "build"
-    environment: "pypi"
-    # Steps to publish to PyPI.
+    # IMPORTANT: this permission is mandatory for trusted publishing.
+    permissions:
+      id-token: "write"
     steps:
       - name: "Retrieve built package from cache"
         uses: "actions/download-artifact@v4"
@@ -65,11 +66,6 @@ jobs:
           path: "dist/"
       - name: "Publish package distributions to PyPI"
         uses: "pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e"  # v1.13.0
-        ## Used for networktocode org since trusted publisher isn't supported for GitHub Plan.
-        with:
-          user: "__token__"
-          password: "${{ secrets.PYPI_API_TOKEN }}"
-        # End publish to PyPI job.
 
   slack-notify:
     needs:

--- a/changes/+trusted-publisher.housekeeping
+++ b/changes/+trusted-publisher.housekeeping
@@ -1,0 +1,1 @@
+Work on trusted publisher for networktocode org.


### PR DESCRIPTION
Environments option is not needed/available for trusted publisher in certain GH plans. Its an optional functionality for trusted publisher in PyPi. Working with internal teams to handle the pypi side, but this change should allow trusted publisher to work and follow our dev standards best practices.