### PR TITLE
add back environments so deployments are tracked

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
     runs-on: "ubuntu-latest"
     if: "startsWith(github.ref, 'refs/tags/v')"
     needs: "build"
+    environment: "pypi"
     # IMPORTANT: this permission is mandatory for trusted publishing.
     permissions:
       id-token: "write"

--- a/changes/gh-env.housekeeping
+++ b/changes/gh-env.housekeeping
@@ -1,0 +1,1 @@
+Add back environments so deployments are tracked in GitHub.


### PR DESCRIPTION
Final research shows you can use env in legacy GH plan just don't have some of the settings pages.

- Deployments still work — you can POST deployments with any environment string and see them in the repo's deployment history, since that's core repo API with no plan gate.
- You cannot open the environment settings page, so no environment secrets, no required reviewers, no wait timers, no deployment branch policies. Repo- and org-level secrets are your only option, and they're visible to every workflow.
- environment: pypi in a workflow won't gate anything; it just labels the deployment.
